### PR TITLE
Hotfix/fhir resource 7.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ iceberg/
 
 # work dir
 tmp/
+studies/
+notes/

--- a/iceberg_tools/__init__.py
+++ b/iceberg_tools/__init__.py
@@ -1,0 +1,31 @@
+import logging
+from typing import Union
+
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def monkey_patch_url_validate():
+    # monkey patch to allow file: urls
+    import fhir.resources.fhirtypes
+    from pydantic import FileUrl
+
+    original_url_validate = fhir.resources.fhirtypes.Url.validate
+
+
+    @classmethod
+    def better_url_validate(  # type: ignore
+            cls, value: str, field: "ModelField", config: "BaseConfig"
+    ) -> Union["AnyUrl", str]:
+        """Allow file: urls. see https://github.com/pydantic/pydantic/issues/1983
+        bugfix: addresses issue introduced with `fhir.resources`==7.0.1
+        """
+        if value.startswith("file:"):
+            return FileUrl.validate(value, field, config)
+        value = original_url_validate(value, field, config)
+        return value
+
+
+    fhir.resources.fhirtypes.Url.validate = better_url_validate
+    logger.debug("monkey patched Url.validate")
+
+monkey_patch_url_validate()

--- a/iceberg_tools/cli/__init__.py
+++ b/iceberg_tools/cli/__init__.py
@@ -6,7 +6,6 @@ from iceberg_tools.cli.data import cli as data
 from iceberg_tools.cli.schema import cli as schema
 from iceberg_tools.util import NaturalOrderGroup
 
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/iceberg_tools/data/simplifier/__init__.py
+++ b/iceberg_tools/data/simplifier/__init__.py
@@ -694,7 +694,7 @@ def simplify_directory(input_path, pattern, output_path, schema_path, dialect, c
     with SimplifierContextManager():
         with EmitterContextManager(output_path) as emitter:
             for parse_result in directory_reader(directory_path=input_path, pattern=pattern,
-                                                 validate=False):
+                                                 validate=False, ignore_path=output_path):
                 if parse_result.exception is not None:
                     if 'resourceType' not in str(parse_result.exception):
                         logger.error(f"{parse_result.path} has exception {parse_result.exception}")

--- a/iceberg_tools/util.py
+++ b/iceberg_tools/util.py
@@ -117,7 +117,8 @@ def directory_reader(
         directory_path: pathlib.Path,
         pattern: str = '*.*',
         parse=True,
-        validate=True) -> Iterator[ParseResult]:
+        validate=True,
+        ignore_path:str =None) -> Iterator[ParseResult]:
     """Extract FHIR resources from directory
 
     Args:
@@ -125,12 +126,15 @@ def directory_reader(
         pattern (str, optional): glob pattern. Defaults to '*.*'.
         parse (bool, optional): parse FHIR resources. Defaults to True.
         validate (bool, optional): validate FHIR resources. Defaults to True.
+        ignore_path (str, optional): ignore files with this string in path. Defaults to None.
     """
 
     assert directory_path.is_dir(), f"{directory_path.name} is not a directory"
 
     input_files = [_ for _ in directory_path.glob(pattern) if _is_json_file(_.name)]
     for input_file in input_files:
+        if ignore_path is not None and ignore_path in str(input_file):
+            continue
         logger.info(input_file)
         if not input_file.is_file():
             continue

--- a/tests/unit/test_url_validate_monkey_patch.py
+++ b/tests/unit/test_url_validate_monkey_patch.py
@@ -1,0 +1,28 @@
+import pytest
+from pydantic import ValidationError
+
+from iceberg_tools import monkey_patch_url_validate
+
+monkey_patch_url_validate()
+
+from fhir.resources.attachment import Attachment  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    'value',
+    ['file:///foo/bar', 'file://localhost/foo/bar', 'file:////localhost/foo/bar', 'filex://localhost/foo/bar'],
+)
+def test_valid_file_url(value):
+    """Should not raise an exception."""
+    a = Attachment.validate({"url": value})
+    assert a.url == value, f"{a.url} should be {value}"
+
+
+@pytest.mark.parametrize(
+    'value',
+    ['file:foo/bar', 'file:'],
+)
+def test_invalid_file_url(value):
+    """Should raise an exception."""
+    with pytest.raises(ValidationError):
+        Attachment.validate({"url": value})


### PR DESCRIPTION
This PR addresses two issues:
* The latest release of the `fhir.resource==7.0.1` library causes file:// urls without a hostname to fail validation. We monkey patch to address
* The simplify command's directory_reader will re-process a previous run's output files if the output_path was set to a subdirectory of an input path 