### PR TITLE
Adds separate config & schema for pfb paper

### DIFF
--- a/tests/integration/data/config.yaml
+++ b/tests/integration/data/config.yaml
@@ -1,0 +1,218 @@
+# subclass_depth: 3  # default is 3 uncomment to override for fhir json schema
+
+
+# This limits the top level objects the system will render
+# For some output targets, e.g. PFB order of output is important, parents must be rendered before children
+dependency_order:
+  #
+  # gen3 scaffolding required objects
+  #
+  - _definitions.yaml
+  - _terms.yaml
+  - Program
+  - Project
+  #
+  # FHIR objects
+  #
+  - Organization
+  - Location
+  - Practitioner
+  - PractitionerRole
+  - ResearchStudy
+  - Patient
+  - ResearchSubject
+  - Substance
+  - Specimen
+  - Encounter
+  - Observation
+  - DiagnosticReport
+  - Condition
+  - Medication
+  - MedicationAdministration
+  - Procedure
+  - DocumentReference
+  - Task
+  - FamilyMemberHistory
+  - BodyStructure
+  - Immunization
+
+
+# Properties to 'pluck' from nested objects and render in the parent object
+nested_objects:
+  Patient:
+    - address.postalCode
+  Specimen:
+    - processing.additive
+    - processing.method
+  DocumentReference:
+    - content.attachment.contentType
+    - content.attachment.extension.md5
+    - content.attachment.size
+    - content.attachment.url
+  Task:
+    - input.valueReference
+    - output.valueReference
+
+# Specify which entities you want to add to a FHIR entities model
+extensions:
+  Patient:
+  - http://hl7.org/fhir/us/core/STU6/StructureDefinition-us-core-race.json
+  - http://hl7.org/fhir/us/core/STU6/StructureDefinition-us-core-ethnicity.json
+  - http://hl7.org/fhir/us/core/STU6/StructureDefinition-us-core-tribal-affiliation.json
+  - http://hl7.org/fhir/us/core/STU6/StructureDefinition-us-core-birthsex.json
+  - http://hl7.org/fhir/us/core/STU6/StructureDefinition-us-core-genderIdentity.json
+  - http://synthetichealth.github.io/synthea/disability-adjusted-life-years
+  - http://synthetichealth.github.io/synthea/quality-adjusted-life-years
+  - https://hl7.org/fhir/extensions/StructureDefinition-patient-birthPlace.json
+  - https://hl7.org/fhir/extensions/StructureDefinition-patient-mothersMaidenName.json
+
+
+# Constrain the parent destination links from a Node for the Simplified Model.
+limit_links:
+  Observation:
+    - ResearchStudy
+    - Patient
+    - Specimen
+  Encounter:
+    - Patient
+  DocumentReference:
+    - Patient
+    - Specimen
+
+# Add these extra properties to the simplified schema
+# These may be used to add extra scalar properties to the simplified schema as well as constrain edge destination types.
+extra_properties:
+
+  # Add gen3 file scaffolding expected properties
+  DocumentReference:
+    $ref: "_definitions.yaml#/data_file_properties"
+    data_category:
+      term:
+        $ref: "_terms.yaml#/data_category"
+      type: string
+    data_type:
+      term:
+        $ref: "_terms.yaml#/data_type"
+      type: string
+    data_format:
+      term:
+        $ref: "_terms.yaml#/data_format"
+      type: string
+    auth_resource_path:
+        type: string
+        description: Gen3 scaffolding
+#    # from content attachment
+#    content_url:
+#        type: string
+#        description: from content attachment
+#    content_contentType:
+#        type: string
+#        description: from content attachment
+#    content_size:
+#        type: number
+#        description: from content attachment
+#    content_md5:
+#        type: string
+#        description: from content attachment
+    # from denormalization
+    patient_id:
+        type: string
+        description: Denormalized patient id
+
+  # a link that does not exist in the FHIR schema, in this case from ResearchStudy to Project
+  ResearchStudy:
+    gen3_project:
+      description: The Gen3 project this study belongs to.  Used to generate link.
+      $ref: Reference.yaml
+      backref: research_study
+      enum_reference_types:
+      - Project
+      title: The Gen3 project this study belongs to.
+
+  # Create edges from references typed as ANY
+  # In this case Task we hint that Task inputs will point to Specimen and outputs point to DocumentReferences
+  # see:
+  # * https://build.fhir.org/task-definitions.html#Task.input.value_x_
+  # * https://build.fhir.org/task-definitions.html#Task.output.value_x_
+
+  Task:
+    specimen:
+      description: The specimen input to this task.  Used to generate link.
+      $ref: Reference.yaml
+      backref: task
+      enum_reference_types:
+      - Specimen
+      title: The specimen input to this task.
+    document_reference:
+      description: The output from this task.  Used to generate link.
+      $ref: Reference.yaml
+      backref: task
+      enum_reference_types:
+      - DocumentReference
+      title: The output from this task.
+
+  # explicitly limit edge `focus` to ResearchStudy
+  Observation:
+    focus:
+      backref: focus_observation
+      description: The actual focus of an observation when it is not the patient of
+        record representing something or someone associated with the patient such as
+        a spouse, parent, fetus, or donor.
+      element_property: true
+      enum_reference_types:
+      - ResearchStudy
+      items:
+        $ref: Reference.yaml
+      title: What the observation is about, when it is not about the subject of record
+      type: array
+
+  # add a link from a sub-object collection.bodySite
+  Specimen:
+    bodySite:
+      backref: specimen
+      $ref: CodeableReference.yaml
+      binding_description: SNOMED CT Body site concepts
+      binding_strength: example
+      binding_uri: http://hl7.org/fhir/ValueSet/body-site
+      binding_version: null
+      description: Anatomical location from which the specimen was collected (if subject
+        is a patient). This is the target site.  This element is not used for environmental
+        specimens.
+      element_property: true
+      enum_reference_types:
+      - BodyStructure
+      title: Anatomical collection site
+
+
+# Add a `category` field to the simplified schema: defaults to Clinical
+categories:
+  DocumentReference: data_file
+  Location: Administrative
+  Organization: Administrative
+  Patient: Administrative
+  Practitioner: Administrative
+  PractitionerRole: Administrative
+  ResearchStudy: Administrative
+  ResearchSubject: Administrative
+  Specimen: Biospecimen
+  Task: Analysis
+
+
+# Ignore these properties in all objects
+ignored_properties:
+  - contained
+  - meta
+  - implicitRules
+  - language
+  - contained
+  - modifierExtension
+  - assigner
+  - fhir_comments
+  - text
+
+
+# Rename these properties
+renamed_properties:
+  label: label_ # https://cdis.slack.com/archives/CDDPLU1NU/p1682393064223499
+  for: for_fhir  # https://github.com/nazrulworld/fhir.resources/blob/main/fhir/resources/task.py#L145
+  class: class_fhir

--- a/tests/integration/data/schemas/_core_metadata_collection.yaml
+++ b/tests/integration/data/schemas/_core_metadata_collection.yaml
@@ -1,0 +1,116 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: false
+category: administrative
+description: A collection of data files in a project.  DEPRECATED - included for portal
+  compatibility
+id: core_metadata_collection
+links:
+- backref: core_metadata_collections
+  label: data_from
+  multiplicity: many_to_one
+  name: projects
+  required: true
+  target_type: project
+namespace: https://data.midrc.org
+nodeTerms: null
+program: '*'
+project: '*'
+properties:
+  $ref: _definitions.yaml#/ubiquitous_properties
+  contributor:
+    description: An entity responsible for making contributions to the resource. Examples
+      of a Contributor include a person, an organization, or a service. Typically,
+      the name of a Contributor should be used to indicate the entity.
+    type: string
+  coverage:
+    description: The spatial or temporal topic of the resource, the spatial applicability
+      of the resource, or the jurisdiction under which the resource is relevant. Spatial
+      topic and spatial applicability may be a named place or a location specified
+      by its geographic coordinates. Temporal topic may be a named period, date, or
+      date range. A jurisdiction may be a named administrative entity or a geographic
+      place to which the resource applies. Recommended best practice is to use a controlled
+      vocabulary such as the Thesaurus of Geographic Names [TGN] (http-//www.getty.edu/research/tools/vocabulary/tgn/index.html).
+      Where appropriate, named places or time periods can be used in preference to
+      numeric identifiers such as sets of coordinates or date ranges.
+    type: string
+  creator:
+    description: An entity primarily responsible for making the resource. Examples
+      of a Creator include a person, an organization, or a service. Typically, the
+      name of a Creator should be used to indicate the entity.
+    type: string
+  data_type:
+    description: The nature or genre of the resource. Recommended best practice is
+      to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE].
+      To describe the file format, physical medium, or dimensions of the resource,
+      use the Format element.
+    type: string
+  date:
+    description: The date the collection of data was created.
+    type: string
+  description:
+    description: An account of the resource. Description may include but is not limited
+      to- an abstract, a table of contents, a graphical representation, or a free-text
+      account of the resource.
+    type: string
+  format:
+    description: The file format, physical medium, or dimensions of the resource.
+      Examples of dimensions include size and duration. Recommended best practice
+      is to use a controlled vocabulary such as the list of Internet Media Types [MIME]
+      (http-//www.iana.org/assignments/media-types/).
+    type: string
+  language:
+    description: A language of the resource. Recommended best practice is to use a
+      controlled vocabulary such as RFC 4646 (http-//www.ietf.org/rfc/rfc4646.txt).
+    type: string
+  projects:
+    $ref: _definitions.yaml#/to_one_project
+    description: The project code for the record in the project node that this core_metadata_collection
+      belongs to, i.e., a link to the parent node.
+  publisher:
+    description: An entity responsible for making the resource available. Examples
+      of a Publisher include a person, an organization, or a service. Typically, the
+      name of a Publisher should be used to indicate the entity.
+    type: string
+  relation:
+    description: A related resource. Recommended best practice is to identify the
+      related resource by means of a string conforming to a formal identification
+      system.
+    type: string
+  rights:
+    description: Information about rights held in and over the resource. Typically,
+      rights information includes a statement about various property rights associated
+      with the resource, including intellectual property rights.
+    type: string
+  source:
+    description: A related resource from which the described resource is derived.
+      The described resource may be derived from the related resource in whole or
+      in part. Recommended best practice is to identify the related resource by means
+      of a string conforming to a formal identification system.
+    type: string
+  subject:
+    description: The topic of the resource. Typically, the subject will be represented
+      using keywords, key phrases, or classification codes. Recommended best practice
+      is to use a controlled vocabulary.
+    type: string
+  title:
+    description: A name given to the resource. Typically, a Title will be a name by
+      which the resource is formally known.
+    type: string
+required:
+- submitter_id
+- type
+- projects
+submittable: true
+systemProperties:
+- id
+- project_id
+- state
+- created_datetime
+- updated_datetime
+title: Core Metadata Collection
+type: object
+uniqueKeys:
+- - id
+- - project_id
+  - submitter_id
+validators: null

--- a/tests/integration/data/schemas/_definitions.yaml
+++ b/tests/integration/data/schemas/_definitions.yaml
@@ -1,0 +1,230 @@
+$schema: http://json-schema.org/draft-04/schema#
+UUID:
+  pattern: ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+  term:
+    $ref: _terms.yaml#/UUID
+  type: string
+data_bundle_state:
+  default: submitted
+  description: State of a data bundle.
+  enum:
+  - submitted
+  - validated
+  - error
+  - released
+  - suppressed
+  - redacted
+data_file_error_type:
+  enum:
+  - file_size
+  - file_format
+  - md5sum
+  term:
+    $ref: _terms.yaml#/data_file_error_type
+data_file_properties:
+  $ref: '#/ubiquitous_properties'
+  error_type:
+    $ref: '#/data_file_error_type'
+  file_format:
+    $ref: '#/file_format'
+  file_name:
+    $ref: '#/file_name'
+  file_size:
+    $ref: '#/file_size'
+  file_state:
+    $ref: '#/file_state'
+  ga4gh_drs_uri:
+    $ref: '#/ga4gh_drs_uri'
+  md5sum:
+    $ref: '#/md5sum'
+  object_id:
+    $ref: '#/object_id'
+datetime:
+  oneOf:
+  - format: date-time
+    type: string
+  - type: 'null'
+  term:
+    $ref: _terms.yaml#/datetime
+fhir_resource:
+  additionalProperties: true
+  properties:
+    id:
+      $ref: '#/UUID'
+    resource_type:
+      type: string
+  type: object
+file_format:
+  term:
+    $ref: _terms.yaml#/file_format
+  type: string
+file_name:
+  term:
+    $ref: _terms.yaml#/file_name
+  type: string
+file_size:
+  term:
+    $ref: _terms.yaml#/file_size
+  type: integer
+file_state:
+  default: registered
+  enum:
+  - registered
+  - uploading
+  - uploaded
+  - validating
+  - validated
+  - submitted
+  - processing
+  - processed
+  - released
+  - error
+  term:
+    $ref: _terms.yaml#/file_state
+foreign_key:
+  additionalProperties: true
+  properties:
+    id:
+      $ref: '#/UUID'
+    submitter_id:
+      type: string
+  type: object
+foreign_key_project:
+  additionalProperties: true
+  properties:
+    code:
+      type: string
+    id:
+      $ref: '#/UUID'
+  type: object
+ga4gh_drs_uri:
+  term:
+    $ref: _terms.yaml#/ga4gh_drs_uri
+  type: string
+id: _definitions
+md5sum:
+  pattern: ^[a-f0-9]{32}$
+  term:
+    $ref: _terms.yaml#/md5sum
+  type: string
+object_id:
+  description: The GUID of the object in the index service.
+  type: string
+parent_uuids:
+  items:
+    $ref: '#/UUID'
+  minItems: 1
+  type: array
+  uniqueItems: true
+project_id:
+  term:
+    $ref: _terms.yaml#/project_id
+  type: string
+qc_metrics_state:
+  enum:
+  - FAIL
+  - PASS
+  - WARN
+  term:
+    $ref: _terms.yaml#/qc_metric_state
+release_state:
+  default: unreleased
+  description: Release state of an entity.
+  enum:
+  - unreleased
+  - released
+  - redacted
+state:
+  default: validated
+  downloadable:
+  - uploaded
+  - md5summed
+  - validating
+  - validated
+  - error
+  - invalid
+  - released
+  oneOf:
+  - enum:
+    - uploading
+    - uploaded
+    - md5summing
+    - md5summed
+    - validating
+    - error
+    - invalid
+    - suppressed
+    - redacted
+    - live
+  - enum:
+    - validated
+    - submitted
+    - released
+  public:
+  - live
+  term:
+    $ref: _terms.yaml#/state
+to_many:
+  anyOf:
+  - items:
+      $ref: '#/foreign_key'
+      minItems: 1
+    type: array
+  - $ref: '#/foreign_key'
+to_many_project:
+  anyOf:
+  - items:
+      $ref: '#/foreign_key_project'
+      minItems: 1
+    type: array
+  - $ref: '#/foreign_key_project'
+to_one:
+  anyOf:
+  - items:
+      $ref: '#/foreign_key'
+      maxItems: 1
+      minItems: 1
+    type: array
+  - $ref: '#/foreign_key'
+to_one_project:
+  anyOf:
+  - items:
+      $ref: '#/foreign_key_project'
+      maxItems: 1
+      minItems: 1
+    type: array
+  - $ref: '#/foreign_key_project'
+ubiquitous_properties:
+  created_datetime:
+    $ref: '#/datetime'
+  id:
+    $ref: '#/UUID'
+    systemAlias: node_id
+  project_id:
+    $ref: '#/project_id'
+  state:
+    $ref: '#/state'
+  submitter_id:
+    description: 'A project-specific identifier for a node. This property is the calling
+      card/nickname/alias for a unit of submission. It can be used in place of the
+      UUID for identifying or recalling a node.
+
+      '
+    type:
+    - string
+  type:
+    type: string
+  updated_datetime:
+    $ref: '#/datetime'
+workflow_properties:
+  $ref: '#/ubiquitous_properties'
+  workflow_end_datetime:
+    $ref: '#/datetime'
+  workflow_link:
+    description: Link to Github hash for the CWL workflow used.
+    type: string
+  workflow_start_datetime:
+    $ref: '#/datetime'
+  workflow_version:
+    description: Major version for a GDC workflow.
+    type: string

--- a/tests/integration/data/schemas/_program.yaml
+++ b/tests/integration/data/schemas/_program.yaml
@@ -1,0 +1,34 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: false
+category: administrative
+description: 'A broad framework of goals to be achieved. (NCIt C52647)
+
+  '
+id: program
+links: []
+program: '*'
+project: '*'
+properties:
+  dbgap_accession_number:
+    description: The dbgap accession number provided for the program.
+    type: string
+  id:
+    $ref: _definitions.yaml#/UUID
+    systemAlias: node_id
+  name:
+    description: Full name/title of the program.
+    type: string
+  type:
+    type: string
+required:
+- name
+- dbgap_accession_number
+submittable: false
+systemProperties:
+- id
+title: Program
+type: object
+uniqueKeys:
+- - id
+- - name
+validators: null

--- a/tests/integration/data/schemas/_project.yaml
+++ b/tests/integration/data/schemas/_project.yaml
@@ -1,0 +1,113 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: false
+category: administrative
+constraints: null
+description: 'Any specifically defined piece of work that is undertaken or attempted
+  to meet a single requirement. (NCIt C47885)
+
+  '
+id: project
+links:
+- backref: projects
+  label: member_of
+  multiplicity: many_to_one
+  name: programs
+  required: true
+  target_type: program
+program: '*'
+project: '*'
+properties:
+  availability_mechanism:
+    description: Mechanism by which the project will be made avilable.
+    type: string
+  availability_type:
+    description: Is the project open or restricted?
+    enum:
+    - Open
+    - Restricted
+  code:
+    description: Unique identifier for the project.
+    type: string
+  date_collected:
+    description: The date or date range in which the project data was collected.
+    type: string
+  dbgap_accession_number:
+    description: The dbgap accession number provided for the project.
+    type: string
+  id:
+    $ref: _definitions.yaml#/UUID
+    description: UUID for the project.
+    systemAlias: node_id
+  intended_release_date:
+    description: Tracks a Project's intended release date.
+    format: date-time
+    type: string
+  investigator_affiliation:
+    description: The investigator's affiliation with respect to a research institution.
+    type: string
+  investigator_name:
+    description: Name of the principal investigator for the project.
+    type: string
+  name:
+    description: Display name/brief description for the project.
+    type: string
+  programs:
+    $ref: _definitions.yaml#/to_one
+    description: 'Indicates that the project is logically part of the indicated project.
+
+      '
+  releasable:
+    default: false
+    description: 'A project can only be released by the user when `releasable` is
+      true.
+
+      '
+    type: boolean
+  released:
+    default: false
+    description: 'To release a project is to tell the GDC to include all submitted
+
+      entities in the next GDC index.
+
+      '
+    type: boolean
+  state:
+    default: open
+    description: 'The possible states a project can be in.  All but `open` are
+
+      equivalent to some type of locked state.
+
+      '
+    enum:
+    - open
+    - review
+    - submitted
+    - processing
+    - closed
+    - legacy
+  support_id:
+    description: The ID of the source providing support/grant resources.
+    type: string
+  support_source:
+    description: The name of source providing support/grant resources.
+    type: string
+  type:
+    type: string
+required:
+- code
+- name
+- dbgap_accession_number
+- programs
+submittable: true
+systemProperties:
+- id
+- state
+- released
+- releasable
+- intended_release_date
+title: Project
+type: object
+uniqueKeys:
+- - id
+- - code
+validators: null

--- a/tests/integration/data/schemas/_settings.yaml
+++ b/tests/integration/data/schemas/_settings.yaml
@@ -1,0 +1,2 @@
+$schema: http://json-schema.org/draft-04/schema#
+enable_case_cache: false

--- a/tests/integration/data/schemas/_terms.yaml
+++ b/tests/integration/data/schemas/_terms.yaml
@@ -1,0 +1,915 @@
+$schema: http://json-schema.org/draft-04/schema#
+RIN:
+  description: 'A numerical assessment of the integrity of RNA based on the entire
+    electrophoretic trace of the RNA sample including the presence or absence of degradation
+    products.
+
+    '
+  termDef:
+    cde_id: 5278775
+    cde_version: 1.0
+    source: caDSR
+    term: Biospecimen RNA Integrity Number Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5278775&version=1.0
+UUID:
+  description: 'A 128-bit identifier. Depending on the mechanism used to generate
+    it, it is either guaranteed to be different from all other UUIDs/GUIDs generated
+    until 3400 AD or extremely likely to be different. Its relatively small size lends
+    itself well to sorting, ordering, and hashing of all sorts, storing in databases,
+    simple allocation, and ease of programming in general.
+
+    '
+  termDef:
+    cde_id: C54100
+    cde_version: null
+    source: NCIt
+    term: Universally Unique Identifier
+    term_url: https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100
+data_category:
+  description: 'Broad categorization of the contents of the data file.
+
+    '
+data_file_error_type:
+  description: 'Type of error for the data file object.
+
+    '
+data_format:
+  description: 'Format of the data files.
+
+    '
+data_type:
+  description: 'Specific content type of the data file. (CMG)
+
+    '
+datetime:
+  description: 'A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+
+    '
+encoding:
+  description: 'Version of ASCII encoding of quality values found in the file.
+
+    '
+  termDef:
+    cde_id: null
+    cde_version: null
+    source: FastQC
+    term: Encoding
+    term_url: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/1%20Basic%20Statistics.html
+file_format:
+  description: 'The format of the data file object.
+
+    '
+file_name:
+  description: 'The name (or part of a name) of a file (of any type).
+
+    '
+file_size:
+  description: 'The size of the data file (object) in bytes.
+
+    '
+file_state:
+  description: 'The current state of the data file object.
+
+    '
+ga4gh_drs_uri:
+  description: 'DRS URI as defined by GA4GH DRS spec for pointers to file objects.
+
+    '
+id: _terms
+md5sum:
+  description: 'The 128-bit hash value expressed as a 32 digit hexadecimal number
+    used as a file''s digital fingerprint.
+
+    '
+microsatellite_instability_abnormal:
+  description: 'The yes/no indicator to signify the status of a tumor for microsatellite
+    instability.
+
+    '
+  termDef:
+    cde_id: 3123142
+    cde_version: 1.0
+    source: caDSR
+    term: Microsatellite Instability Occurrence Indicator
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3123142&version=1.0
+morphology:
+  description: 'The third edition of the International Classification of Diseases
+    for Oncology, published in 2000 used principally in tumor and cancer registries
+    for coding the site (topography) and the histology (morphology) of neoplasms.
+    The study of the structure of the cells and their arrangement to constitute tissues
+    and, finally, the association among these to form organs. In pathology, the microscopic
+    process of identifying normal and abnormal morphologic characteristics in tissues,
+    by employing various cytochemical and immunocytochemical stains. A system of numbered
+    categories for representation of data.
+
+    '
+  termDef:
+    cde_id: 3226275
+    cde_version: 1.0
+    source: caDSR
+    term: International Classification of Diseases for Oncology, Third Edition ICD-O-3
+      Histology Code
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3226275&version=1.0
+new_event_anatomic_site:
+  description: 'Text term to specify the anatomic location of the return of tumor
+    after treatment.
+
+    '
+  termDef:
+    cde_id: 3108271
+    cde_version: 2.0
+    source: caDSR
+    term: New Neoplasm Event Occurrence Anatomic Site
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3108271&version=2.0
+new_event_type:
+  description: 'Text term to identify a new tumor event.
+
+    '
+  termDef:
+    cde_id: 3119721
+    cde_version: 1.0
+    source: caDSR
+    term: New Neoplasm Event Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3119721&version=1.0
+normal_tumor_genotype_snp_match:
+  description: 'Text term that represents whether or not the genotype of the normal
+    tumor matches or if the data is not available.
+
+    '
+  termDef:
+    cde_id: 4588156
+    cde_version: 1.0
+    source: caDSR
+    term: Normal Tumor Genotype Match Indicator
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4588156&version=1.0
+number_proliferating_cells:
+  description: 'Numeric value that represents the count of proliferating cells determined
+    during pathologic review of the sample slide(s).
+
+    '
+  termDef:
+    cde_id: 5432636
+    cde_version: 1.0
+    source: caDSR
+    term: Pathology Review Slide Proliferating Cell Count
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432636&version=1.0
+oct_embedded:
+  description: 'Indicator of whether or not the sample was embedded in Optimal Cutting
+    Temperature (OCT) compound.
+
+    '
+  termDef:
+    cde_id: 5432538
+    cde_version: 1.0
+    source: caDSR
+    term: Tissue Sample Optimal Cutting Temperature Compound Embedding Indicator
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432538&version=1.0
+percent_eosinophil_infiltration:
+  description: 'Numeric value to represent the percentage of infiltration by eosinophils
+    in a tumor sample or specimen.
+
+    '
+  termDef:
+    cde_id: 2897700
+    cde_version: 2.0
+    source: caDSR
+    term: Specimen Eosinophilia Percentage Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897700&version=2.0
+percent_gc_content:
+  description: 'The overall %GC of all bases in all sequences.
+
+    '
+  termDef:
+    cde_id: null
+    cde_version: null
+    source: FastQC
+    term: '%GC'
+    term_url: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/1%20Basic%20Statistics.html
+percent_granulocyte_infiltration:
+  description: 'Numeric value to represent the percentage of infiltration by granulocytes
+    in a tumor sample or specimen.
+
+    '
+  termDef:
+    cde_id: 2897705
+    cde_version: 2.0
+    source: caDSR
+    term: Specimen Granulocyte Infiltration Percentage Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897705&version=2.0
+percent_inflam_infiltration:
+  description: 'Numeric value to represent local response to cellular injury, marked
+    by capillary dilatation, edema and leukocyte infiltration; clinically, inflammation
+    is manifest by reddness, heat, pain, swelling and loss of function, with the need
+    to heal damaged tissue.
+
+    '
+  termDef:
+    cde_id: 2897695
+    cde_version: 1.0
+    source: caDSR
+    term: Specimen Inflammation Change Percentage Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897695&version=1.0
+percent_lymphocyte_infiltration:
+  description: 'Numeric value to represent the percentage of infiltration by lymphocytes
+    in a solid tissue normal sample or specimen.
+
+    '
+  termDef:
+    cde_id: 2897710
+    cde_version: 2.0
+    source: caDSR
+    term: Specimen Lymphocyte Infiltration Percentage Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897710&version=2.0
+percent_monocyte_infiltration:
+  description: 'Numeric value to represent the percentage of monocyte infiltration
+    in a sample or specimen.
+
+    '
+  termDef:
+    cde_id: 5455535
+    cde_version: 1.0
+    source: caDSR
+    term: Specimen Monocyte Infiltration Percentage Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5455535&version=1.0
+percent_necrosis:
+  description: 'Numeric value to represent the percentage of cell death in a malignant
+    tumor sample or specimen.
+
+    '
+  termDef:
+    cde_id: 2841237
+    cde_version: 1.0
+    source: caDSR
+    term: Malignant Neoplasm Necrosis Percentage Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841237&version=1.0
+percent_neutrophil_infiltration:
+  description: 'Numeric value to represent the percentage of infiltration by neutrophils
+    in a tumor sample or specimen.
+
+    '
+  termDef:
+    cde_id: 2841267
+    cde_version: 1.0
+    source: caDSR
+    term: Malignant Neoplasm Neutrophil Infiltration Percentage Cell Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841267&version=1.0
+percent_normal_cells:
+  description: 'Numeric value to represent the percentage of normal cell content in
+    a malignant tumor sample or specimen.
+
+    '
+  termDef:
+    cde_id: 2841233
+    cde_version: 1.0
+    source: caDSR
+    term: Malignant Neoplasm Normal Cell Percentage Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841233&version=1.0
+percent_stromal_cells:
+  description: 'Numeric value to represent the percentage of reactive cells that are
+    present in a malignant tumor sample or specimen but are not malignant such as
+    fibroblasts, vascular structures, etc.
+
+    '
+  termDef:
+    cde_id: 2841241
+    cde_version: 1.0
+    source: caDSR
+    term: Malignant Neoplasm Stromal Cell Percentage Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841241&version=1.0
+percent_tumor_cells:
+  description: 'Numeric value that represents the percentage of infiltration by granulocytes
+    in a sample.
+
+    '
+  termDef:
+    cde_id: 5432686
+    cde_version: 1.0
+    source: caDSR
+    term: Specimen Tumor Cell Percentage Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432686&version=1.0
+percent_tumor_nuclei:
+  description: 'Numeric value to represent the percentage of tumor nuclei in a malignant
+    neoplasm sample or specimen.
+
+    '
+  termDef:
+    cde_id: 2841225
+    cde_version: 1.0
+    source: caDSR
+    term: Malignant Neoplasm Neoplasm Nucleus Percentage Cell Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841225&version=1.0
+perineural_invasion_present:
+  description: 'a yes/no indicator to ask if perineural invasion or infiltration of
+    tumor or cancer is present.
+
+    '
+  termDef:
+    cde_id: 64181
+    cde_version: 3.0
+    source: caDSR
+    term: Tumor Perineural Invasion Ind
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=64181&version=3.0
+platform:
+  description: 'Name of the platform used to obtain data.
+
+    '
+portion_number:
+  description: 'Numeric value that represents the sequential number assigned to a
+    portion of the sample.
+
+    '
+  termDef:
+    cde_id: 5432711
+    cde_version: 1.0
+    source: caDSR
+    term: Biospecimen Portion Sequence Number
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432711&version=1.0
+portion_weight:
+  description: 'Numeric value that represents the sample portion weight, measured
+    in milligrams.
+
+    '
+  termDef:
+    cde_id: 5432593
+    cde_version: 1.0
+    source: caDSR
+    term: Biospecimen Portion Weight Milligram Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432593&version=1.0
+preservation_method:
+  description: 'Text term that represents the method used to preserve the sample.
+
+    '
+  termDef:
+    cde_id: 5432521
+    cde_version: 1.0
+    source: caDSR
+    term: Tissue Sample Preservation Method Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432521&version=1.0
+prior_malignancy:
+  description: 'Text term to describe the patient''s history of prior cancer diagnosis
+    and the spatial location of any previous cancer occurrence.
+
+    '
+  termDef:
+    cde_id: 3382736
+    cde_version: 2.0
+    source: caDSR
+    term: Prior Cancer Diagnosis Occurrence Description Text
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3382736&version=2.0
+prior_treatment:
+  description: 'A yes/no/unknown/not applicable indicator related to the administration
+    of therapeutic agents received before the body specimen was collected.
+
+    '
+  termDef:
+    cde_id: 4231463
+    cde_version: 1.0
+    source: caDSR
+    term: Therapeutic Procedure Prior Specimen Collection Administered Yes No Unknown
+      Not Applicable Indicator
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4231463&version=1.0
+progesterone_receptor_percent_positive_ihc:
+  description: 'Classification to represent Progesterone Receptor Positive results
+    expressed as a percentage value.
+
+    '
+  termDef:
+    cde_id: 3128342
+    cde_version: 1.0
+    source: caDSR
+    term: Progesterone Receptor Level Cell Percentage Category
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3128342&version=1.0
+progesterone_receptor_result_ihc:
+  description: 'Text term to represent the overall result of Progresterone Receptor
+    (PR) testing.
+
+    '
+  termDef:
+    cde_id: 2957357
+    cde_version: 2.0
+    source: caDSR
+    term: Breast Carcinoma Progesterone Receptor Status
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2957357&version=2.0
+progression_or_recurrence:
+  description: 'Yes/No/Unknown indicator to identify whether a patient has had a new
+    tumor event after initial treatment.
+
+    '
+  termDef:
+    cde_id: 3121376
+    cde_version: 1.0
+    source: caDSR
+    term: New Neoplasm Event Post Initial Therapy Indicator
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3121376&version=1.0
+project_id:
+  description: 'Unique ID for any specific defined piece of work that is undertaken
+    or attempted to meet a single requirement.
+
+    '
+qc_metric_state:
+  description: 'State classification given by FASTQC for the metric. Metric specific
+    details about the states are available on their website.
+
+    '
+  termDef:
+    cde_id: null
+    cde_version: null
+    source: FastQC
+    term: QC Metric State
+    term_url: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/
+race:
+  description: 'An arbitrary classification of a taxonomic group that is a division
+    of a species (HARMONIZED). It usually arises as a consequence of geographical
+    isolation within a species and is characterized by shared heredity, physical attributes
+    and behavior, and in the case of humans, by common history, nationality, or geographic
+    distribution. The provided values are based on the categories defined by the U.S.
+    Office of Management and Business and used by the U.S. Census Bureau. (GTEx)
+
+    '
+  termDef:
+    cde_id: 2192199
+    cde_version: 1.0
+    source: caDSR
+    term: Race Category Text
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2192199&version=1.0
+read_group_name:
+  description: 'The name of the read group.
+
+    '
+read_length:
+  description: 'The length of the reads.
+
+    '
+relationship_age_at_diagnosis:
+  description: 'The age (in years) when the patient''s relative was first diagnosed.
+
+    '
+  termDef:
+    cde_id: 5300571
+    cde_version: 1.0
+    source: caDSR
+    term: Relative Diagnosis Age Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5300571&version=1.0
+relationship_to_proband:
+  description: 'The subgroup that describes the state of connectedness between members
+    of the unit of society organized around kinship ties.
+
+    '
+  termDef:
+    cde_id: 2690165
+    cde_version: 2.0
+    source: caDSR
+    term: Family Member Relationship Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2690165&version=2.0
+relationship_type:
+  description: 'The subgroup that describes the state of connectedness between members
+    of the unit of society organized around kinship ties.
+
+    '
+  termDef:
+    cde_id: 2690165
+    cde_version: 2.0
+    source: caDSR
+    term: Family Member Relationship Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2690165&version=2.0
+relative_with_cancer_history:
+  description: 'Indicator to signify whether or not an individual''s biological relative
+    has been diagnosed with another type of cancer.
+
+    '
+  termDef:
+    cde_id: 3901752
+    cde_version: 1.0
+    source: caDSR
+    term: Other Cancer Biological Relative History Indicator
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3901752&version=1.0
+residual_disease:
+  description: 'Text terms to describe the status of a tissue margin following surgical
+    resection.
+
+    '
+  termDef:
+    cde_id: 2608702
+    cde_version: 1.0
+    source: caDSR
+    term: Surgical Margin Resection Status
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2608702&version=1.0
+sample_type:
+  description: 'Text term to describe the source of a biospecimen used for a laboratory
+    test.
+
+    '
+  termDef:
+    cde_id: 3111302
+    cde_version: 2.0
+    source: caDSR
+    term: Specimen Type Collection Biospecimen Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3111302&version=2.0
+sample_type_id:
+  description: 'The accompanying sample type id for the sample type.
+
+    '
+section_location:
+  description: 'Tissue source of the slide.
+
+    '
+sequencing_center:
+  description: 'Name of the center that provided the sequence files.
+
+    '
+shortest_dimension:
+  description: 'Numeric value that represents the shortest dimension of the sample,
+    measured in millimeters.
+
+    '
+  termDef:
+    cde_id: 5432603
+    cde_version: 1.0
+    source: caDSR
+    term: Tissue Sample Short Dimension Millimeter Measurement
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432603&version=1.0
+site_of_resection_or_biopsy:
+  description: 'The third edition of the International Classification of Diseases
+    for Oncology, published in 2000, used principally in tumor and cancer registries
+    for coding the site (topography) and the histology (morphology) of neoplasms.
+    The description of an anatomical region or of a body part. Named locations of,
+    or within, the body. A system of numbered categories for representation of data.
+
+    '
+  termDef:
+    cde_id: 3226281
+    cde_version: 1.0
+    source: caDSR
+    term: International Classification of Diseases for Oncology, Third Edition ICD-O-3
+      Site Code
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3226281&version=1.0
+size_selection_range:
+  description: 'Range of size selection.
+
+    '
+smoking_history:
+  description: 'Category describing current smoking status and smoking history as
+    self-reported by a patient.
+
+    '
+  termDef:
+    cde_id: 2181650
+    cde_version: 1.0
+    source: caDSR
+    term: Smoking History
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2181650&version=1.0
+smoking_intensity:
+  description: 'Numeric computed value to represent lifetime tobacco exposure defined
+    as number of cigarettes smoked per day x number of years smoked divided by 20
+
+    '
+  termDef:
+    cde_id: 2955385
+    cde_version: 1.0
+    source: caDSR
+    term: Person Cigarette Smoking History Pack Year Value
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2955385&version=1.0
+source_center:
+  description: 'Name of the center that provided the item.
+
+    '
+spectrophotometer_method:
+  description: 'Name of the method used to determine the concentration of purified
+    nucleic acid within a solution.
+
+    '
+  termDef:
+    cde_id: 3008378
+    cde_version: 1.0
+    source: caDSR
+    term: Purification Nucleic Acid Solution Concentration Determination Method Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3008378&version=1.0
+spike_ins_concentration:
+  description: 'Spike in concentration.
+
+    '
+spike_ins_fasta:
+  description: 'Name of the FASTA file that contains the spike-in sequences.
+
+    '
+state:
+  description: 'The current state of the object.
+
+    '
+target_capture_kit_catalog_number:
+  description: 'Catalog of Target Capture Kit.
+
+    '
+target_capture_kit_name:
+  description: 'Name of Target Capture Kit.
+
+    '
+target_capture_kit_target_region:
+  description: 'Target Capture Kit BED file.
+
+    '
+target_capture_kit_vendor:
+  description: 'Vendor of Target Capture Kit.
+
+    '
+target_capture_kit_version:
+  description: 'Version of Target Capture Kit.
+
+    '
+therapeutic_agents:
+  description: 'Text identification of the individual agent(s) used as part of a prior
+    treatment regimen.
+
+    '
+  termDef:
+    cde_id: 2975232
+    cde_version: 1.0
+    source: caDSR
+    term: Prior Therapy Regimen Text
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2975232&version=1.0
+time_between_clamping_and_freezing:
+  description: 'Numeric representation of the elapsed time between the surgical clamping
+    of blood supply and freezing of the sample, measured in minutes.
+
+    '
+  termDef:
+    cde_id: 5432611
+    cde_version: 1.0
+    source: caDSR
+    term: Tissue Sample Clamping and Freezing Elapsed Minute Time
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432611&version=1.0
+time_between_excision_and_freezing:
+  description: 'Numeric representation of the elapsed time between the excision and
+    freezing of the sample, measured in minutes.
+
+    '
+  termDef:
+    cde_id: 5432612
+    cde_version: 1.0
+    source: caDSR
+    term: Tissue Sample Excision and Freezing Elapsed Minute Time
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432612&version=1.0
+tissue_or_organ_of_origin:
+  description: 'Text term that describes the anatomic site of the tumor or disease.
+
+    '
+  termDef:
+    cde_id: 3427536
+    cde_version: 3.0
+    source: caDSR
+    term: Tumor Disease Anatomic Site
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3427536&version=3.0
+tissue_type:
+  description: 'Text term that represents a description of the kind of tissue collected
+    with respect to disease status or proximity to tumor tissue.
+
+    '
+  termDef:
+    cde_id: 5432687
+    cde_version: 1.0
+    source: caDSR
+    term: Tissue Sample Description Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432687&version=1.0
+to_trim_adapter_sequence:
+  description: 'Does the user suggest adapter trimming?
+
+    '
+tobacco_smoking_onset_year:
+  description: 'The year in which the participant began smoking.
+
+    '
+  termDef:
+    cde_id: 2228604
+    cde_version: 1.0
+    source: caDSR
+    term: Started Smoking Year
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2228604&version=1.0
+tobacco_smoking_quit_year:
+  description: 'The year in which the participant quit smoking.
+
+    '
+  termDef:
+    cde_id: 2228610
+    cde_version: 1.0
+    source: caDSR
+    term: Stopped Smoking Year
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2228610&version=1.0
+tobacco_smoking_status:
+  description: 'Category describing current smoking status and smoking history as
+    self-reported by a patient.
+
+    '
+  termDef:
+    cde_id: 2181650
+    cde_version: 1.0
+    source: caDSR
+    term: Patient Smoking History Category
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2181650&version=1.0
+total_sequences:
+  description: 'A count of the total number of sequences processed.
+
+    '
+  termDef:
+    cde_id: null
+    cde_version: null
+    source: FastQC
+    term: Total Sequences
+    term_url: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/1%20Basic%20Statistics.html
+treatment_anatomic_site:
+  description: 'The anatomic site or field targeted by a treatment regimen or single
+    agent therapy.
+
+    '
+  termDef:
+    cde_id: null
+    cde_version: null
+    source: null
+    term: Treatment Anatomic Site
+    term_url: null
+treatment_intent_type:
+  description: 'Text term to identify the reason for the administration of a treatment
+    regimen. [Manually-curated]
+
+    '
+  termDef:
+    cde_id: 2793511
+    cde_version: 1.0
+    source: caDSR
+    term: Treatment Regimen Intent Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2793511&version=1.0
+treatment_or_therapy:
+  description: 'A yes/no/unknown/not applicable indicator related to the administration
+    of therapeutic agents received before the body specimen was collected.
+
+    '
+  termDef:
+    cde_id: 4231463
+    cde_version: 1.0
+    source: caDSR
+    term: Therapeutic Procedure Prior Specimen Collection Administered Yes No Unknown
+      Not Applicable Indicator
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4231463&version=1.0
+treatment_outcome:
+  description: "Text term that describes the patient\xBFs final outcome after the\
+    \ treatment was administered.\n"
+  termDef:
+    cde_id: 5102383
+    cde_version: 1.0
+    source: caDSR
+    term: Treatment Outcome Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5102383&version=1.0
+treatment_type:
+  description: 'Text term that describes the kind of treatment administered.
+
+    '
+  termDef:
+    cde_id: 5102381
+    cde_version: 1.0
+    source: caDSR
+    term: Treatment Method Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5102381&version=1.0
+tumor_code:
+  description: 'Diagnostic tumor code of the tissue sample source.
+
+    '
+tumor_code_id:
+  description: 'BCR-defined id code for the tumor sample.
+
+    '
+tumor_descriptor:
+  description: 'Text that describes the kind of disease present in the tumor specimen
+    as related to a specific timepoint.
+
+    '
+  termDef:
+    cde_id: 3288124
+    cde_version: 1.0
+    source: caDSR
+    term: Tumor Tissue Disease Description Type
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3288124&version=1.0
+tumor_grade:
+  description: 'Numeric value to express the degree of abnormality of cancer cells,
+    a measure of differentiation and aggressiveness.
+
+    '
+  termDef:
+    cde_id: 2785839
+    cde_version: 2.0
+    source: caDSR
+    term: Neoplasm Histologic Grade
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2785839&version=2.0
+tumor_stage:
+  description: 'The extent of a cancer in the body. Staging is usually based on the
+    size of the tumor, whether lymph nodes contain cancer, and whether the cancer
+    has spread from the original site to other parts of the body. The accepted values
+    for tumor_stage depend on the tumor site, type, and accepted staging system. These
+    items should accompany the tumor_stage value as associated metadata.
+
+    '
+  termDef:
+    cde_id: C16899
+    cde_version: null
+    source: NCIt
+    term: Tumor Stage
+    term_url: https://ncit.nci.nih.gov/ncitbrowser/pages/concept_details.jsf?dictionary=NCI%20Thesaurus&code=C16899
+vascular_invasion_present:
+  description: 'The yes/no indicator to ask if large vessel or venous invasion was
+    detected by surgery or presence in a tumor specimen.
+
+    '
+  termDef:
+    cde_id: 64358
+    cde_version: 3.0
+    source: caDSR
+    term: Tumor Vascular Invasion Ind-3
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=64358&version=3.0
+vital_status:
+  description: 'The survival state of the person registered on the protocol.
+
+    '
+  termDef:
+    cde_id: 5
+    cde_version: 5.0
+    source: caDSR
+    term: Patient Vital Status
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5&version=5.0
+weight:
+  description: 'The weight of the patient measured in lbs (HARMONIZED).
+
+    '
+  termDef:
+    cde_id: 651
+    cde_version: 4.0
+    source: caDSR
+    term: Patient Weight Measurement
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=651&version=4.0
+well_number:
+  description: 'Numeric value that represents the the well location within a plate
+    for the analyte or aliquot from the sample.
+
+    '
+  termDef:
+    cde_id: 5432613
+    cde_version: 1.0
+    source: caDSR
+    term: Biospecimen Analyte or Aliquot Plate Well Number
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432613&version=1.0
+workflow_type:
+  description: 'Generic name for the workflow used to analyze a data set.
+
+    '
+year_of_birth:
+  description: 'Numeric value to represent the calendar year in which an individual
+    was born.
+
+    '
+  termDef:
+    cde_id: 2896954
+    cde_version: 1.0
+    source: caDSR
+    term: Year Birth Date Number
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2896954&version=1.0
+year_of_death:
+  description: 'Numeric value to represent the year of the death of an individual.
+
+    '
+  termDef:
+    cde_id: 2897030
+    cde_version: 1.0
+    source: caDSR
+    term: Year Death Number
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897030&version=1.0
+year_of_diagnosis:
+  description: 'Numeric value to represent the year of an individual''s initial pathologic
+    diagnosis of cancer.
+
+    '
+  termDef:
+    cde_id: 2896960
+    cde_version: 1.0
+    source: caDSR
+    term: Year of initial pathologic diagnosis
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2896960&version=1.0
+years_smoked:
+  description: 'Numeric value (or unknown) to represent the number of years a person
+    has been smoking (HARMONIZED). If the number of years is greater than 89, see
+    ''years_smoked_gt89''.
+
+    '
+  termDef:
+    cde_id: 3137957
+    cde_version: 1.0
+    source: caDSR
+    term: Person Smoking Duration Year Count
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3137957&version=1.0
+years_smoked_gt89:
+  description: 'Indicate whether the numeric value to represent the number of years
+    a person has been smoking (HARMONIZED) is greater than 89 years.
+
+    '
+  termDef:
+    cde_id: 3137957
+    cde_version: 1.0
+    source: caDSR
+    term: Person Smoking Duration Year Count
+    term_url: https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3137957&version=1.0

--- a/tests/integration/data/schemas/body_structure.yaml
+++ b/tests/integration/data/schemas/body_structure.yaml
@@ -1,0 +1,159 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: Specific and identified anatomical structure. Record details about an
+  anatomical structure.  This resource may be used when a coded concept does not provide
+  the necessary detail needed for the use case. [See https://hl7.org/fhir/R5/BodyStructure.html]
+id: body_structure
+links:
+- backref: body_structure
+  label: BodyStructure_patient_Patient_body_structure
+  multiplicity: many_to_many
+  name: patient
+  required: false
+  target_type: patient
+program: '*'
+project: '*'
+properties:
+  active:
+    description: Whether this body site is in active use.
+    element_property: true
+    title: Whether this record is in active use
+    type: boolean
+  description:
+    description: A summary, characterization or explanation of the body structure.
+    element_property: true
+    pattern: \s*(\S|\s)*
+    title: Text description
+    type: string
+  excludedStructure:
+    description: '[Text representation of BodyStructureIncludedStructure] The anatomical
+      location(s) or region(s) not occupied or represented by the specimen, lesion,
+      or body structure.'
+    element_property: true
+    items:
+      type: string
+    title: Excluded anatomic locations(s)
+    type: array
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Identifier for this instance of the anatomical structure.
+    element_property: true
+    items:
+      type: string
+    title: Bodystructure identifier
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Identifier for this instance
+      of the anatomical structure.'
+    element_property: true
+    items:
+      type: string
+    title: Bodystructure identifier
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Identifier for this
+      instance of the anatomical structure.'
+    element_property: true
+    items:
+      type: string
+    title: Bodystructure identifier
+    type: array
+  image:
+    description: '[Text representation of Attachment] Image or images used to identify
+      a location.'
+    element_property: true
+    items:
+      type: string
+    title: Attached images
+    type: array
+  includedStructure:
+    description: '[Text representation of BodyStructureIncludedStructure] The anatomical
+      location(s) or region(s) of the specimen, lesion, or body structure.'
+    element_property: true
+    items:
+      type: string
+    title: Included anatomic location(s)
+    type: array
+  morphology:
+    binding_description: Codes describing anatomic morphology.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/bodystructure-code
+    binding_version: null
+    description: text representation. The kind of structure being represented by the
+      body structure at `BodyStructure.location`.  This can define both normal and
+      abnormal morphologies.
+    element_property: true
+    term:
+      description: Codes describing anatomic morphology.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/bodystructure-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/bodystructure-code
+        term_url: http://hl7.org/fhir/ValueSet/bodystructure-code
+    title: Kind of Structure
+    type: string
+  morphology_coding: &id001
+    binding_description: Codes describing anatomic morphology.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/bodystructure-code
+    binding_version: null
+    description: '[system#code representation.] The kind of structure being represented
+      by the body structure at `BodyStructure.location`.  This can define both normal
+      and abnormal morphologies.'
+    element_property: true
+    term:
+      description: Codes describing anatomic morphology.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/bodystructure-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/bodystructure-code
+        term_url: http://hl7.org/fhir/ValueSet/bodystructure-code
+    title: Kind of Structure
+    type: string
+  morphology_text: *id001
+  patient:
+    backref: body_structure
+    description: '[Text representation of Reference] The person to which the body
+      site belongs.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    title: Who this is about
+    type: string
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  resourceType:
+    const: BodyStructure
+    default: BodyStructure
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+title: BodyStructure
+type: object

--- a/tests/integration/data/schemas/condition.yaml
+++ b/tests/integration/data/schemas/condition.yaml
@@ -1,0 +1,533 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: Detailed information about conditions, problems or diagnoses. A clinical
+  condition, problem, diagnosis, or other event, situation, issue, or clinical concept
+  that has risen to a level of concern. [See https://hl7.org/fhir/R5/Condition.html]
+id: condition
+links:
+- backref: condition
+  label: Condition_subject_Patient_condition
+  multiplicity: many_to_many
+  name: subject_Patient
+  required: false
+  target_type: patient
+- backref: condition
+  label: Condition_encounter_Encounter_condition
+  multiplicity: many_to_many
+  name: encounter
+  required: false
+  target_type: encounter
+program: '*'
+project: '*'
+properties:
+  abatementAge:
+    description: '[Text representation of Age] The date or estimated date that the
+      condition resolved or went into remission. This is called "abatement" because
+      of the many overloaded connotations associated with "remission" or "resolution"
+      - Some conditions, such as chronic conditions, are never really resolved, but
+      they can abate.'
+    element_property: true
+    one_of_many: abatement
+    one_of_many_required: false
+    title: When in resolution/remission
+    type: string
+  abatementDateTime:
+    description: The date or estimated date that the condition resolved or went into
+      remission. This is called "abatement" because of the many overloaded connotations
+      associated with "remission" or "resolution" - Some conditions, such as chronic
+      conditions, are never really resolved, but they can abate.
+    element_property: true
+    format: date-time
+    one_of_many: abatement
+    one_of_many_required: false
+    title: When in resolution/remission
+    type: string
+  abatementPeriod:
+    description: '[Text representation of Period] The date or estimated date that
+      the condition resolved or went into remission. This is called "abatement" because
+      of the many overloaded connotations associated with "remission" or "resolution"
+      - Some conditions, such as chronic conditions, are never really resolved, but
+      they can abate.'
+    element_property: true
+    one_of_many: abatement
+    one_of_many_required: false
+    title: When in resolution/remission
+    type: string
+  abatementRange:
+    description: '[Text representation of Range] The date or estimated date that the
+      condition resolved or went into remission. This is called "abatement" because
+      of the many overloaded connotations associated with "remission" or "resolution"
+      - Some conditions, such as chronic conditions, are never really resolved, but
+      they can abate.'
+    element_property: true
+    one_of_many: abatement
+    one_of_many_required: false
+    title: When in resolution/remission
+    type: string
+  abatementString:
+    description: The date or estimated date that the condition resolved or went into
+      remission. This is called "abatement" because of the many overloaded connotations
+      associated with "remission" or "resolution" - Some conditions, such as chronic
+      conditions, are never really resolved, but they can abate.
+    element_property: true
+    one_of_many: abatement
+    one_of_many_required: false
+    pattern: '[ \r\n\t\S]+'
+    title: When in resolution/remission
+    type: string
+  bodySite:
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: text representation. The anatomical location where this condition
+      manifests itself.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Anatomical location, if relevant
+    type: array
+  bodySite_coding: &id001
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: '[system#code representation.] The anatomical location where this
+      condition manifests itself.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Anatomical location, if relevant
+    type: array
+  bodySite_text: *id001
+  category:
+    binding_description: A category assigned to the condition.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-category
+    binding_version: null
+    description: text representation. A category assigned to the condition.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A category assigned to the condition.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-category
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/condition-category
+        term_url: http://hl7.org/fhir/ValueSet/condition-category
+    title: problem-list-item | encounter-diagnosis
+    type: array
+  category_coding: &id002
+    binding_description: A category assigned to the condition.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-category
+    binding_version: null
+    description: '[system#code representation.] A category assigned to the condition.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A category assigned to the condition.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-category
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/condition-category
+        term_url: http://hl7.org/fhir/ValueSet/condition-category
+    title: problem-list-item | encounter-diagnosis
+    type: array
+  category_text: *id002
+  clinicalStatus:
+    binding_description: The clinical status of the condition or diagnosis.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-clinical
+    binding_version: 5.0.0
+    description: text representation. The clinical status of the condition.
+    element_property: true
+    term:
+      description: The clinical status of the condition or diagnosis.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-clinical
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/ValueSet/condition-clinical
+        term_url: http://hl7.org/fhir/ValueSet/condition-clinical
+    title: active | recurrence | relapse | inactive | remission | resolved | unknown
+    type: string
+  clinicalStatus_coding: &id003
+    binding_description: The clinical status of the condition or diagnosis.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-clinical
+    binding_version: 5.0.0
+    description: '[system#code representation.] The clinical status of the condition.'
+    element_property: true
+    term:
+      description: The clinical status of the condition or diagnosis.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-clinical
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/ValueSet/condition-clinical
+        term_url: http://hl7.org/fhir/ValueSet/condition-clinical
+    title: active | recurrence | relapse | inactive | remission | resolved | unknown
+    type: string
+  clinicalStatus_text: *id003
+  code:
+    binding_description: Identification of the condition or diagnosis.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-code
+    binding_version: null
+    description: text representation. Identification of the condition, problem or
+      diagnosis
+    element_property: true
+    term:
+      description: Identification of the condition or diagnosis.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/condition-code
+        term_url: http://hl7.org/fhir/ValueSet/condition-code
+    title: Identification of the condition, problem or diagnosis
+    type: string
+  code_coding: &id004
+    binding_description: Identification of the condition or diagnosis.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-code
+    binding_version: null
+    description: '[system#code representation.] Identification of the condition, problem
+      or diagnosis'
+    element_property: true
+    term:
+      description: Identification of the condition or diagnosis.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/condition-code
+        term_url: http://hl7.org/fhir/ValueSet/condition-code
+    title: Identification of the condition, problem or diagnosis
+    type: string
+  code_text: *id004
+  encounter:
+    backref: condition
+    description: '[Text representation of Reference] The Encounter during which this
+      Condition was created or to which the creation of this record is tightly associated.'
+    element_property: true
+    enum_reference_types:
+    - Encounter
+    title: The Encounter during which this Condition was created
+    type: string
+  evidence:
+    backref: evidence_condition
+    binding_description: null
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/clinical-findings
+    binding_version: null
+    description: text representation. Supporting evidence / manifestations that are
+      the basis of the Condition's verification status, such as evidence that confirmed
+      or refuted the condition.
+    element_property: true
+    enum_reference_types:
+    - Resource
+    items:
+      type: string
+    term:
+      description: null
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/clinical-findings
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/clinical-findings
+        term_url: http://hl7.org/fhir/ValueSet/clinical-findings
+    title: Supporting evidence for the verification status
+    type: array
+  evidence_coding: &id005
+    backref: evidence_condition
+    binding_description: null
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/clinical-findings
+    binding_version: null
+    description: '[system#code representation.] Supporting evidence / manifestations
+      that are the basis of the Condition''s verification status, such as evidence
+      that confirmed or refuted the condition.'
+    element_property: true
+    enum_reference_types:
+    - Resource
+    items:
+      type: string
+    term:
+      description: null
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/clinical-findings
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/clinical-findings
+        term_url: http://hl7.org/fhir/ValueSet/clinical-findings
+    title: Supporting evidence for the verification status
+    type: array
+  evidence_text: *id005
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Business identifiers assigned to this condition by the performer
+      or other systems which remain constant as the resource is updated and propagates
+      from server to server.
+    element_property: true
+    items:
+      type: string
+    title: External Ids for this condition
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Business identifiers
+      assigned to this condition by the performer or other systems which remain constant
+      as the resource is updated and propagates from server to server.'
+    element_property: true
+    items:
+      type: string
+    title: External Ids for this condition
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Business identifiers
+      assigned to this condition by the performer or other systems which remain constant
+      as the resource is updated and propagates from server to server.'
+    element_property: true
+    items:
+      type: string
+    title: External Ids for this condition
+    type: array
+  note:
+    description: '[Text representation of Annotation] Additional information about
+      the Condition. This is a general notes/comments entry  for description of the
+      Condition, its diagnosis and prognosis.'
+    element_property: true
+    items:
+      type: string
+    title: Additional information about the Condition
+    type: array
+  onsetAge:
+    description: '[Text representation of Age] Estimated or actual date or date-time  the
+      condition began, in the opinion of the clinician.'
+    element_property: true
+    one_of_many: onset
+    one_of_many_required: false
+    title: Estimated or actual date,  date-time, or age
+    type: string
+  onsetDateTime:
+    description: Estimated or actual date or date-time  the condition began, in the
+      opinion of the clinician.
+    element_property: true
+    format: date-time
+    one_of_many: onset
+    one_of_many_required: false
+    title: Estimated or actual date,  date-time, or age
+    type: string
+  onsetPeriod:
+    description: '[Text representation of Period] Estimated or actual date or date-time  the
+      condition began, in the opinion of the clinician.'
+    element_property: true
+    one_of_many: onset
+    one_of_many_required: false
+    title: Estimated or actual date,  date-time, or age
+    type: string
+  onsetRange:
+    description: '[Text representation of Range] Estimated or actual date or date-time  the
+      condition began, in the opinion of the clinician.'
+    element_property: true
+    one_of_many: onset
+    one_of_many_required: false
+    title: Estimated or actual date,  date-time, or age
+    type: string
+  onsetString:
+    description: Estimated or actual date or date-time  the condition began, in the
+      opinion of the clinician.
+    element_property: true
+    one_of_many: onset
+    one_of_many_required: false
+    pattern: '[ \r\n\t\S]+'
+    title: Estimated or actual date,  date-time, or age
+    type: string
+  participant:
+    description: '[Text representation of ConditionParticipant] Indicates who or what
+      participated in the activities related to the condition and how they were involved.'
+    element_property: true
+    items:
+      type: string
+    title: Who or what participated in the activities related to the condition and
+      how they were involved
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  recordedDate:
+    description: The recordedDate represents when this particular Condition record
+      was created in the system, which is often a system-generated date.
+    element_property: true
+    format: date-time
+    title: Date condition was first recorded
+    type: string
+  resourceType:
+    const: Condition
+    default: Condition
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  severity:
+    binding_description: A subjective assessment of the severity of the condition
+      as evaluated by the clinician.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-severity
+    binding_version: null
+    description: text representation. A subjective assessment of the severity of the
+      condition as evaluated by the clinician.
+    element_property: true
+    term:
+      description: A subjective assessment of the severity of the condition as evaluated
+        by the clinician.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-severity
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/condition-severity
+        term_url: http://hl7.org/fhir/ValueSet/condition-severity
+    title: Subjective severity of condition
+    type: string
+  severity_coding: &id006
+    binding_description: A subjective assessment of the severity of the condition
+      as evaluated by the clinician.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-severity
+    binding_version: null
+    description: '[system#code representation.] A subjective assessment of the severity
+      of the condition as evaluated by the clinician.'
+    element_property: true
+    term:
+      description: A subjective assessment of the severity of the condition as evaluated
+        by the clinician.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-severity
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/condition-severity
+        term_url: http://hl7.org/fhir/ValueSet/condition-severity
+    title: Subjective severity of condition
+    type: string
+  severity_text: *id006
+  stage:
+    description: '[Text representation of ConditionStage] A simple summary of the
+      stage such as "Stage 3" or "Early Onset". The determination of the stage is
+      disease-specific, such as cancer, retinopathy of prematurity, kidney diseases,
+      Alzheimer''s, or Parkinson disease.'
+    element_property: true
+    items:
+      type: string
+    title: Stage/grade, usually assessed formally
+    type: array
+  subject:
+    backref: condition
+    description: '[Text representation of Reference] Indicates the patient or group
+      who the condition record is associated with.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Group
+    title: Who has the condition?
+    type: string
+  verificationStatus:
+    binding_description: The verification status to support or decline the clinical
+      status of the condition or diagnosis.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-ver-status
+    binding_version: 5.0.0
+    description: text representation. The verification status to support the clinical
+      status of the condition.  The verification status pertains to the condition,
+      itself, not to any specific condition attribute.
+    element_property: true
+    term:
+      description: The verification status to support or decline the clinical status
+        of the condition or diagnosis.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-ver-status
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/ValueSet/condition-ver-status
+        term_url: http://hl7.org/fhir/ValueSet/condition-ver-status
+    title: unconfirmed | provisional | differential | confirmed | refuted | entered-in-error
+    type: string
+  verificationStatus_coding: &id007
+    binding_description: The verification status to support or decline the clinical
+      status of the condition or diagnosis.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-ver-status
+    binding_version: 5.0.0
+    description: '[system#code representation.] The verification status to support
+      the clinical status of the condition.  The verification status pertains to the
+      condition, itself, not to any specific condition attribute.'
+    element_property: true
+    term:
+      description: The verification status to support or decline the clinical status
+        of the condition or diagnosis.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-ver-status
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/ValueSet/condition-ver-status
+        term_url: http://hl7.org/fhir/ValueSet/condition-ver-status
+    title: unconfirmed | provisional | differential | confirmed | refuted | entered-in-error
+    type: string
+  verificationStatus_text: *id007
+title: Condition
+type: object

--- a/tests/integration/data/schemas/diagnostic_report.yaml
+++ b/tests/integration/data/schemas/diagnostic_report.yaml
@@ -1,0 +1,477 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: A Diagnostic report - a combination of request information, atomic results,
+  images, interpretation, as well as formatted reports. The findings and interpretation
+  of diagnostic tests performed on patients, groups of patients, products, substances,
+  devices, and locations, and/or specimens derived from these. The report includes
+  clinical context such as requesting provider information, and some mix of atomic
+  results, images, textual and coded interpretations, and formatted representation
+  of diagnostic reports. The report also includes non-clinical context such as batch
+  analysis and stability reporting of products and substances. [See https://hl7.org/fhir/R5/DiagnosticReport.html]
+id: diagnostic_report
+links:
+- backref: subject_diagnostic_report
+  label: DiagnosticReport_subject_Patient_subject_diagnostic_report
+  multiplicity: many_to_many
+  name: subject_Patient
+  required: false
+  target_type: patient
+- backref: subject_diagnostic_report
+  label: DiagnosticReport_subject_Location_subject_diagnostic_report
+  multiplicity: many_to_many
+  name: subject_Location
+  required: false
+  target_type: location
+- backref: subject_diagnostic_report
+  label: DiagnosticReport_subject_Organization_subject_diagnostic_report
+  multiplicity: many_to_many
+  name: subject_Organization
+  required: false
+  target_type: organization
+- backref: subject_diagnostic_report
+  label: DiagnosticReport_subject_Practitioner_subject_diagnostic_report
+  multiplicity: many_to_many
+  name: subject_Practitioner
+  required: false
+  target_type: practitioner
+- backref: subject_diagnostic_report
+  label: DiagnosticReport_subject_Medication_subject_diagnostic_report
+  multiplicity: many_to_many
+  name: subject_Medication
+  required: false
+  target_type: medication
+- backref: subject_diagnostic_report
+  label: DiagnosticReport_subject_Substance_subject_diagnostic_report
+  multiplicity: many_to_many
+  name: subject_Substance
+  required: false
+  target_type: substance
+- backref: diagnostic_report
+  label: DiagnosticReport_encounter_Encounter_diagnostic_report
+  multiplicity: many_to_many
+  name: encounter
+  required: false
+  target_type: encounter
+- backref: performer_diagnostic_report
+  label: DiagnosticReport_performer_PractitionerRole_performer_diagnostic_report
+  multiplicity: many_to_many
+  name: performer_PractitionerRole
+  required: false
+  target_type: practitioner_role
+- backref: result_diagnostic_report
+  label: DiagnosticReport_result_Observation_result_diagnostic_report
+  multiplicity: many_to_many
+  name: result
+  required: false
+  target_type: observation
+- backref: specimen_diagnostic_report
+  label: DiagnosticReport_specimen_Specimen_specimen_diagnostic_report
+  multiplicity: many_to_many
+  name: specimen
+  required: false
+  target_type: specimen
+program: '*'
+project: '*'
+properties:
+  basedOn:
+    backref: basedOn_diagnostic_report
+    description: '[Text representation of Reference] Details concerning a service
+      requested.'
+    element_property: true
+    enum_reference_types:
+    - CarePlan
+    - ImmunizationRecommendation
+    - MedicationRequest
+    - NutritionOrder
+    - ServiceRequest
+    items:
+      type: string
+    title: What was requested
+    type: array
+  category:
+    binding_description: HL7 V2 table 0074
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
+    binding_version: null
+    description: text representation. A code that classifies the clinical discipline,
+      department or diagnostic service that created the report (e.g. cardiology, biochemistry,
+      hematology, MRI). This is used for searching, sorting and display purposes.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: HL7 V2 table 0074
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
+        term_url: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
+    title: Service category
+    type: array
+  category_coding: &id001
+    binding_description: HL7 V2 table 0074
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
+    binding_version: null
+    description: '[system#code representation.] A code that classifies the clinical
+      discipline, department or diagnostic service that created the report (e.g. cardiology,
+      biochemistry, hematology, MRI). This is used for searching, sorting and display
+      purposes.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: HL7 V2 table 0074
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
+        term_url: http://hl7.org/fhir/ValueSet/diagnostic-service-sections
+    title: Service category
+    type: array
+  category_text: *id001
+  code:
+    binding_description: LOINC Codes for Diagnostic Reports
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/report-codes
+    binding_version: null
+    description: text representation. A code or name that describes this diagnostic
+      report.
+    element_property: true
+    term:
+      description: LOINC Codes for Diagnostic Reports
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/report-codes
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/report-codes
+        term_url: http://hl7.org/fhir/ValueSet/report-codes
+    title: Name/Code for this diagnostic report
+    type: string
+  code_coding: &id002
+    binding_description: LOINC Codes for Diagnostic Reports
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/report-codes
+    binding_version: null
+    description: '[system#code representation.] A code or name that describes this
+      diagnostic report.'
+    element_property: true
+    term:
+      description: LOINC Codes for Diagnostic Reports
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/report-codes
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/report-codes
+        term_url: http://hl7.org/fhir/ValueSet/report-codes
+    title: Name/Code for this diagnostic report
+    type: string
+  code_text: *id002
+  composition:
+    backref: diagnostic_report
+    description: '[Text representation of Reference] Reference to a Composition resource
+      instance that provides structure for organizing the contents of the DiagnosticReport.'
+    element_property: true
+    enum_reference_types:
+    - Composition
+    title: Reference to a Composition resource for the DiagnosticReport structure
+    type: string
+  conclusion:
+    description: Concise and clinically contextualized summary conclusion (interpretation/impression)
+      of the diagnostic report.
+    element_property: true
+    pattern: \s*(\S|\s)*
+    title: Clinical conclusion (interpretation) of test results
+    type: string
+  conclusionCode:
+    binding_description: SNOMED CT Clinical Findings
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/clinical-findings
+    binding_version: null
+    description: text representation. One or more codes that represent the summary
+      conclusion (interpretation/impression) of the diagnostic report.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: SNOMED CT Clinical Findings
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/clinical-findings
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/clinical-findings
+        term_url: http://hl7.org/fhir/ValueSet/clinical-findings
+    title: Codes for the clinical conclusion of test results
+    type: array
+  conclusionCode_coding: &id003
+    binding_description: SNOMED CT Clinical Findings
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/clinical-findings
+    binding_version: null
+    description: '[system#code representation.] One or more codes that represent the
+      summary conclusion (interpretation/impression) of the diagnostic report.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: SNOMED CT Clinical Findings
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/clinical-findings
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/clinical-findings
+        term_url: http://hl7.org/fhir/ValueSet/clinical-findings
+    title: Codes for the clinical conclusion of test results
+    type: array
+  conclusionCode_text: *id003
+  effectiveDateTime:
+    description: The time or time-period the observed values are related to. When
+      the subject of the report is a patient, this is usually either the time of the
+      procedure or of specimen collection(s), but very often the source of the date/time
+      is not known, only the date/time itself.
+    element_property: true
+    format: date-time
+    one_of_many: effective
+    one_of_many_required: false
+    title: Clinically relevant time/time-period for report
+    type: string
+  effectivePeriod:
+    description: '[Text representation of Period] The time or time-period the observed
+      values are related to. When the subject of the report is a patient, this is
+      usually either the time of the procedure or of specimen collection(s), but very
+      often the source of the date/time is not known, only the date/time itself.'
+    element_property: true
+    one_of_many: effective
+    one_of_many_required: false
+    title: Clinically relevant time/time-period for report
+    type: string
+  encounter:
+    backref: diagnostic_report
+    description: '[Text representation of Reference] The healthcare event  (e.g. a
+      patient and healthcare provider interaction) which this DiagnosticReport is
+      about.'
+    element_property: true
+    enum_reference_types:
+    - Encounter
+    title: Health care event when test ordered
+    type: string
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Identifiers assigned to this report by the performer or other systems.
+    element_property: true
+    items:
+      type: string
+    title: Business identifier for report
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Identifiers assigned
+      to this report by the performer or other systems.'
+    element_property: true
+    items:
+      type: string
+    title: Business identifier for report
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Identifiers assigned
+      to this report by the performer or other systems.'
+    element_property: true
+    items:
+      type: string
+    title: Business identifier for report
+    type: array
+  issued:
+    description: The date and time that this version of the report was made available
+      to providers, typically after the report was reviewed and verified.
+    element_property: true
+    format: date-time
+    title: DateTime this version was made
+    type: string
+  media:
+    description: '[Text representation of DiagnosticReportMedia] A list of key images
+      or data associated with this report. The images or data are generally created
+      during the diagnostic process, and may be directly of the patient, or of treated
+      specimens (i.e. slides of interest).'
+    element_property: true
+    items:
+      type: string
+    title: Key images or data associated with this report
+    type: array
+  note:
+    description: '[Text representation of Annotation] Comments about the diagnostic
+      report'
+    element_property: true
+    items:
+      type: string
+    title: Comments about the diagnostic report
+    type: array
+  performer:
+    backref: performer_diagnostic_report
+    description: '[Text representation of Reference] The diagnostic service that is
+      responsible for issuing the report.'
+    element_property: true
+    enum_reference_types:
+    - Practitioner
+    - PractitionerRole
+    - Organization
+    - CareTeam
+    items:
+      type: string
+    title: Responsible Diagnostic Service
+    type: array
+  presentedForm:
+    description: '[Text representation of Attachment] Rich text representation of
+      the entire result as issued by the diagnostic service. Multiple formats are
+      allowed but they SHALL be semantically equivalent.'
+    element_property: true
+    items:
+      type: string
+    title: Entire report as issued
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  resourceType:
+    const: DiagnosticReport
+    default: DiagnosticReport
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  result:
+    backref: result_diagnostic_report
+    description: '[Text representation of Reference] [Observations](observation.html)  that
+      are part of this diagnostic report.'
+    element_property: true
+    enum_reference_types:
+    - Observation
+    items:
+      type: string
+    title: Observations
+    type: array
+  resultsInterpreter:
+    backref: resultsInterpreter_diagnostic_report
+    description: '[Text representation of Reference] The practitioner or organization
+      that is responsible for the report''s conclusions and interpretations.'
+    element_property: true
+    enum_reference_types:
+    - Practitioner
+    - PractitionerRole
+    - Organization
+    - CareTeam
+    items:
+      type: string
+    title: Primary result interpreter
+    type: array
+  specimen:
+    backref: specimen_diagnostic_report
+    description: '[Text representation of Reference] Details about the specimens on
+      which this diagnostic report is based.'
+    element_property: true
+    enum_reference_types:
+    - Specimen
+    items:
+      type: string
+    title: Specimens this report is based on
+    type: array
+  status:
+    binding_description: The status of the diagnostic report.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/diagnostic-report-status
+    binding_version: 5.0.0
+    description: The status of the diagnostic report.
+    element_property: true
+    element_required: true
+    enum_values:
+    - registered
+    - partial
+    - preliminary
+    - modified
+    - final
+    - amended
+    - corrected
+    - appended
+    - cancelled
+    - entered-in-error
+    - unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: registered | partial | preliminary | modified | final | amended | corrected
+      | appended | cancelled | entered-in-error | unknown
+    type: string
+  study:
+    backref: study_diagnostic_report
+    description: '[Text representation of Reference] One or more links to full details
+      of any study performed during the diagnostic investigation. An ImagingStudy
+      might comprise a set of radiologic images obtained via a procedure that are
+      analyzed as a group. Typically, this is imaging performed by DICOM enabled modalities,
+      but this is not required. A fully enabled PACS viewer can use this information
+      to provide views of the source images. A GenomicStudy might comprise one or
+      more analyses, each serving a specific purpose. These analyses may vary in method
+      (e.g., karyotyping, CNV, or SNV detection), performer, software, devices used,
+      or regions targeted.'
+    element_property: true
+    enum_reference_types:
+    - GenomicStudy
+    - ImagingStudy
+    items:
+      type: string
+    title: Reference to full details of an analysis associated with the diagnostic
+      report
+    type: array
+  subject:
+    backref: subject_diagnostic_report
+    description: '[Text representation of Reference] The subject of the report. Usually,
+      but not always, this is a patient. However, diagnostic services also perform
+      analyses on specimens collected from a variety of other sources.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Group
+    - Device
+    - Location
+    - Organization
+    - Practitioner
+    - Medication
+    - Substance
+    - BiologicallyDerivedProduct
+    title: The subject of the report - usually, but not always, the patient
+    type: string
+  supportingInfo:
+    description: '[Text representation of DiagnosticReportSupportingInfo] This backbone
+      element contains supporting information that was used in the creation of the
+      report not included in the results already included in the report.'
+    element_property: true
+    items:
+      type: string
+    title: Additional information supporting the diagnostic report
+    type: array
+title: DiagnosticReport
+type: object

--- a/tests/integration/data/schemas/document_reference.yaml
+++ b/tests/integration/data/schemas/document_reference.yaml
@@ -1,0 +1,658 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: data_file
+description: "A reference to a document. A reference to a document of any kind for\
+  \ any purpose. While the term \u201Cdocument\u201D implies a more narrow focus,\
+  \ for this resource this \"document\" encompasses *any* serialized object with a\
+  \ mime-type, it includes formal patient-centric documents (CDA), clinical notes,\
+  \ scanned paper, non-patient specific documents like policy text, as well as a photo,\
+  \ video, or audio recording acquired or used in healthcare.  The DocumentReference\
+  \ resource provides metadata about the document so that the document can be discovered\
+  \ and managed.  The actual content may be inline base64 encoded data or provided\
+  \ by direct reference. [See https://hl7.org/fhir/R5/DocumentReference.html]"
+id: document_reference
+links:
+- backref: author_document_reference
+  label: DocumentReference_author_Patient_author_document_reference
+  multiplicity: many_to_many
+  name: author_Patient
+  required: false
+  target_type: patient
+program: '*'
+project: '*'
+properties:
+  $ref: _definitions.yaml#/data_file_properties
+  attester:
+    description: '[Text representation of DocumentReferenceAttester] A participant
+      who has authenticated the accuracy of the document.'
+    element_property: true
+    items:
+      type: string
+    title: Attests to accuracy of the document
+    type: array
+  auth_resource_path:
+    description: Gen3 scaffolding
+    type: string
+  author:
+    backref: author_document_reference
+    description: '[Text representation of Reference] Identifies who is responsible
+      for adding the information to the document.'
+    element_property: true
+    enum_reference_types:
+    - Practitioner
+    - PractitionerRole
+    - Organization
+    - Device
+    - Patient
+    - RelatedPerson
+    - CareTeam
+    items:
+      type: string
+    title: Who and/or what authored the document
+    type: array
+  basedOn:
+    backref: basedOn_document_reference
+    description: '[Text representation of Reference] A procedure that is fulfilled
+      in whole or in part by the creation of this media.'
+    element_property: true
+    enum_reference_types:
+    - Appointment
+    - AppointmentResponse
+    - CarePlan
+    - Claim
+    - CommunicationRequest
+    - Contract
+    - CoverageEligibilityRequest
+    - DeviceRequest
+    - EnrollmentRequest
+    - ImmunizationRecommendation
+    - MedicationRequest
+    - NutritionOrder
+    - RequestOrchestration
+    - ServiceRequest
+    - SupplyRequest
+    - VisionPrescription
+    items:
+      type: string
+    title: Procedure that caused this media to be created
+    type: array
+  bodySite:
+    backref: bodySite_document_reference
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: text representation. The anatomic structures included in the document.
+    element_property: true
+    enum_reference_types:
+    - BodyStructure
+    items:
+      type: string
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Body part included
+    type: array
+  bodySite_coding: &id001
+    backref: bodySite_document_reference
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: '[system#code representation.] The anatomic structures included in
+      the document.'
+    element_property: true
+    enum_reference_types:
+    - BodyStructure
+    items:
+      type: string
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Body part included
+    type: array
+  bodySite_text: *id001
+  category:
+    binding_description: High-level kind of document at a macro level.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/referenced-item-category
+    binding_version: null
+    description: text representation. A categorization for the type of document referenced
+      - helps for indexing and searching. This may be implied by or derived from the
+      code specified in the DocumentReference.type.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: High-level kind of document at a macro level.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/referenced-item-category
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/referenced-item-category
+        term_url: http://hl7.org/fhir/ValueSet/referenced-item-category
+    title: Categorization of document
+    type: array
+  category_coding: &id002
+    binding_description: High-level kind of document at a macro level.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/referenced-item-category
+    binding_version: null
+    description: '[system#code representation.] A categorization for the type of document
+      referenced - helps for indexing and searching. This may be implied by or derived
+      from the code specified in the DocumentReference.type.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: High-level kind of document at a macro level.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/referenced-item-category
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/referenced-item-category
+        term_url: http://hl7.org/fhir/ValueSet/referenced-item-category
+    title: Categorization of document
+    type: array
+  category_text: *id002
+  content_attachment_contentType:
+    binding_description: BCP 13 (RFCs 2045, 2046, 2047, 4288, 4289 and 2049)
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/mimetypes
+    binding_version: 5.0.0
+    description: '[Plucked from DocumentReference.content] Identifies the type of
+      the data in the attachment and allows a method to be chosen to interpret or
+      render the data. Includes mime type parameters such as charset where appropriate.'
+    element_property: true
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: Mime type of the content, with charset etc.
+    type: string
+  content_attachment_extension_md5:
+    description: '[Plucked from DocumentReference.content] Value of extension'
+    type: string
+  content_attachment_size:
+    description: '[Plucked from DocumentReference.content] The number of bytes of
+      data that make up this attachment (before base64 encoding, if that is done).'
+    element_property: true
+    title: Number of bytes of content (if url provided)
+    type: integer
+  content_attachment_url:
+    description: '[Plucked from DocumentReference.content] A location where the data
+      can be accessed.'
+    element_property: true
+    format: uri
+    maxLength: 65536
+    minLength: 1
+    title: Uri where the data can be found
+    type: string
+  context:
+    backref: context_document_reference
+    description: '[Text representation of Reference] Describes the clinical encounter
+      or type of care that the document content is associated with.'
+    element_property: true
+    enum_reference_types:
+    - Appointment
+    - Encounter
+    - EpisodeOfCare
+    items:
+      type: string
+    title: Context of the document content
+    type: array
+  custodian:
+    backref: custodian_document_reference
+    description: '[Text representation of Reference] Identifies the organization or
+      group who is responsible for ongoing maintenance of and access to the document.'
+    element_property: true
+    enum_reference_types:
+    - Organization
+    title: Organization which maintains the document
+    type: string
+  data_category:
+    term:
+      $ref: _terms.yaml#/data_category
+    type: string
+  data_format:
+    term:
+      $ref: _terms.yaml#/data_format
+    type: string
+  data_type:
+    term:
+      $ref: _terms.yaml#/data_type
+    type: string
+  date:
+    description: When the document reference was created.
+    element_property: true
+    format: date-time
+    title: When this document reference was created
+    type: string
+  description:
+    description: Human-readable description of the source document.
+    element_property: true
+    pattern: \s*(\S|\s)*
+    title: Human-readable description
+    type: string
+  docStatus:
+    binding_description: Status of the underlying document.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/composition-status
+    binding_version: 5.0.0
+    description: The status of the underlying document.
+    element_property: true
+    enum_values:
+    - registered
+    - partial
+    - preliminary
+    - final
+    - amended
+    - corrected
+    - appended
+    - cancelled
+    - entered-in-error
+    - deprecated
+    - unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: registered | partial | preliminary | final | amended | corrected | appended
+      | cancelled | entered-in-error | deprecated | unknown
+    type: string
+  event:
+    backref: event_document_reference
+    binding_description: This list of codes represents the main clinical acts being
+      documented.
+    binding_strength: example
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-ActCode
+    binding_version: null
+    description: text representation. This list of codes represents the main clinical
+      acts, such as a colonoscopy or an appendectomy, being documented. In some cases,
+      the event is inherent in the type Code, such as a "History and Physical Report"
+      in which the procedure being documented is necessarily a "History and Physical"
+      act.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: This list of codes represents the main clinical acts being documented.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-ActCode
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://terminology.hl7.org/ValueSet/v3-ActCode
+        term_url: http://terminology.hl7.org/ValueSet/v3-ActCode
+    title: Main clinical acts documented
+    type: array
+  event_coding: &id003
+    backref: event_document_reference
+    binding_description: This list of codes represents the main clinical acts being
+      documented.
+    binding_strength: example
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-ActCode
+    binding_version: null
+    description: '[system#code representation.] This list of codes represents the
+      main clinical acts, such as a colonoscopy or an appendectomy, being documented.
+      In some cases, the event is inherent in the type Code, such as a "History and
+      Physical Report" in which the procedure being documented is necessarily a "History
+      and Physical" act.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: This list of codes represents the main clinical acts being documented.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-ActCode
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://terminology.hl7.org/ValueSet/v3-ActCode
+        term_url: http://terminology.hl7.org/ValueSet/v3-ActCode
+    title: Main clinical acts documented
+    type: array
+  event_text: *id003
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  facilityType:
+    binding_description: XDS Facility Type.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/c80-facilitycodes
+    binding_version: null
+    description: text representation. The kind of facility where the patient was seen.
+    element_property: true
+    term:
+      description: XDS Facility Type.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/c80-facilitycodes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/c80-facilitycodes
+        term_url: http://hl7.org/fhir/ValueSet/c80-facilitycodes
+    title: Kind of facility where patient was seen
+    type: string
+  facilityType_coding: &id004
+    binding_description: XDS Facility Type.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/c80-facilitycodes
+    binding_version: null
+    description: '[system#code representation.] The kind of facility where the patient
+      was seen.'
+    element_property: true
+    term:
+      description: XDS Facility Type.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/c80-facilitycodes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/c80-facilitycodes
+        term_url: http://hl7.org/fhir/ValueSet/c80-facilitycodes
+    title: Kind of facility where patient was seen
+    type: string
+  facilityType_text: *id004
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Other business identifiers associated with the document, including
+      version independent identifiers.
+    element_property: true
+    items:
+      type: string
+    title: Business identifiers for the document
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Other business identifiers
+      associated with the document, including version independent identifiers.'
+    element_property: true
+    items:
+      type: string
+    title: Business identifiers for the document
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Other business identifiers
+      associated with the document, including version independent identifiers.'
+    element_property: true
+    items:
+      type: string
+    title: Business identifiers for the document
+    type: array
+  modality:
+    binding_description: Type of acquired data in the instance.
+    binding_strength: extensible
+    binding_uri: http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html
+    binding_version: null
+    description: text representation. Imaging modality used. This may include both
+      acquisition and non-acquisition modalities.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Type of acquired data in the instance.
+      termDef:
+        cde_id: http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html
+        term_url: http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html
+    title: Imaging modality used
+    type: array
+  modality_coding: &id005
+    binding_description: Type of acquired data in the instance.
+    binding_strength: extensible
+    binding_uri: http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html
+    binding_version: null
+    description: '[system#code representation.] Imaging modality used. This may include
+      both acquisition and non-acquisition modalities.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Type of acquired data in the instance.
+      termDef:
+        cde_id: http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html
+        term_url: http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html
+    title: Imaging modality used
+    type: array
+  modality_text: *id005
+  patient_id:
+    description: Denormalized patient id
+    type: string
+  period:
+    description: '[Text representation of Period] The time period over which the service
+      that is described by the document was provided.'
+    element_property: true
+    title: Time of service that is being documented
+    type: string
+  practiceSetting:
+    binding_description: Additional details about where the content was created (e.g.
+      clinical specialty).
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/c80-practice-codes
+    binding_version: null
+    description: text representation. This property may convey specifics about the
+      practice setting where the content was created, often reflecting the clinical
+      specialty.
+    element_property: true
+    term:
+      description: Additional details about where the content was created (e.g. clinical
+        specialty).
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/c80-practice-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/c80-practice-codes
+        term_url: http://hl7.org/fhir/ValueSet/c80-practice-codes
+    title: Additional details about where the content was created (e.g. clinical specialty)
+    type: string
+  practiceSetting_coding: &id006
+    binding_description: Additional details about where the content was created (e.g.
+      clinical specialty).
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/c80-practice-codes
+    binding_version: null
+    description: '[system#code representation.] This property may convey specifics
+      about the practice setting where the content was created, often reflecting the
+      clinical specialty.'
+    element_property: true
+    term:
+      description: Additional details about where the content was created (e.g. clinical
+        specialty).
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/c80-practice-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/c80-practice-codes
+        term_url: http://hl7.org/fhir/ValueSet/c80-practice-codes
+    title: Additional details about where the content was created (e.g. clinical specialty)
+    type: string
+  practiceSetting_text: *id006
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  relatesTo:
+    description: '[Text representation of DocumentReferenceRelatesTo] Relationships
+      that this document has with other document references that already exist.'
+    element_property: true
+    items:
+      type: string
+    title: Relationships to other documents
+    type: array
+  resourceType:
+    const: DocumentReference
+    default: DocumentReference
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  securityLabel:
+    binding_description: Example Security Labels from the Healthcare Privacy and Security
+      Classification System.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/security-label-examples
+    binding_version: null
+    description: 'text representation. A set of Security-Tag codes specifying the
+      level of privacy/security of the Document found at DocumentReference.content.attachment.url.
+      Note that DocumentReference.meta.security contains the security labels of the
+      data elements in DocumentReference, while DocumentReference.securityLabel contains
+      the security labels for the document the reference refers to. The distinction
+      recognizes that the document may contain sensitive information, while the DocumentReference
+      is metadata about the document and thus might not be as sensitive as the document.
+      For example: a psychotherapy episode may contain highly sensitive information,
+      while the metadata may simply indicate that some episode happened.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Example Security Labels from the Healthcare Privacy and Security
+        Classification System.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/security-label-examples
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/security-label-examples
+        term_url: http://hl7.org/fhir/ValueSet/security-label-examples
+    title: Document security-tags
+    type: array
+  securityLabel_coding: &id007
+    binding_description: Example Security Labels from the Healthcare Privacy and Security
+      Classification System.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/security-label-examples
+    binding_version: null
+    description: '[system#code representation.] A set of Security-Tag codes specifying
+      the level of privacy/security of the Document found at DocumentReference.content.attachment.url.
+      Note that DocumentReference.meta.security contains the security labels of the
+      data elements in DocumentReference, while DocumentReference.securityLabel contains
+      the security labels for the document the reference refers to. The distinction
+      recognizes that the document may contain sensitive information, while the DocumentReference
+      is metadata about the document and thus might not be as sensitive as the document.
+      For example: a psychotherapy episode may contain highly sensitive information,
+      while the metadata may simply indicate that some episode happened.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Example Security Labels from the Healthcare Privacy and Security
+        Classification System.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/security-label-examples
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/security-label-examples
+        term_url: http://hl7.org/fhir/ValueSet/security-label-examples
+    title: Document security-tags
+    type: array
+  securityLabel_text: *id007
+  status:
+    binding_description: The status of the document reference.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/document-reference-status
+    binding_version: 5.0.0
+    description: The status of this document reference.
+    element_property: true
+    element_required: true
+    enum_values:
+    - current
+    - superseded
+    - entered-in-error
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: current | superseded | entered-in-error
+    type: string
+  subject:
+    backref: document_reference
+    description: '[Text representation of Reference] Who or what the document is about.
+      The document can be about a person, (patient or healthcare practitioner), a
+      device (e.g. a machine) or even a group of subjects (such as a document about
+      a herd of farm animals, or a set of patients that share a common exposure).'
+    element_property: true
+    enum_reference_types:
+    - Resource
+    title: Who/what is the subject of the document
+    type: string
+  type:
+    binding_description: Precise type of clinical document.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/doc-typecodes
+    binding_version: null
+    description: text representation. Specifies the particular kind of document referenced  (e.g.
+      History and Physical, Discharge Summary, Progress Note). This usually equates
+      to the purpose of making the document referenced.
+    element_property: true
+    term:
+      description: Precise type of clinical document.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/doc-typecodes
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/doc-typecodes
+        term_url: http://hl7.org/fhir/ValueSet/doc-typecodes
+    title: Kind of document (LOINC if possible)
+    type: string
+  type_coding: &id008
+    binding_description: Precise type of clinical document.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/doc-typecodes
+    binding_version: null
+    description: '[system#code representation.] Specifies the particular kind of document
+      referenced  (e.g. History and Physical, Discharge Summary, Progress Note). This
+      usually equates to the purpose of making the document referenced.'
+    element_property: true
+    term:
+      description: Precise type of clinical document.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/doc-typecodes
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/doc-typecodes
+        term_url: http://hl7.org/fhir/ValueSet/doc-typecodes
+    title: Kind of document (LOINC if possible)
+    type: string
+  type_text: *id008
+  version:
+    description: An explicitly assigned identifer of a variation of the content in
+      the DocumentReference
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: An explicitly assigned identifer of a variation of the content in the DocumentReference
+    type: string
+title: DocumentReference
+type: object

--- a/tests/integration/data/schemas/encounter.yaml
+++ b/tests/integration/data/schemas/encounter.yaml
@@ -1,0 +1,621 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: An interaction during which services are provided to the patient. An
+  interaction between a patient and healthcare provider(s) for the purpose of providing
+  healthcare service(s) or assessing the health status of a patient.  Encounter is
+  primarily used to record information about the actual activities that occurred,
+  where Appointment is used to record planned activities. [See https://hl7.org/fhir/R5/Encounter.html]
+id: encounter
+links:
+- backref: encounter
+  label: Encounter_subject_Patient_encounter
+  multiplicity: many_to_many
+  name: subject_Patient
+  required: false
+  target_type: patient
+program: '*'
+project: '*'
+properties:
+  account:
+    backref: account_encounter
+    description: '[Text representation of Reference] The set of accounts that may
+      be used for billing for this Encounter'
+    element_property: true
+    enum_reference_types:
+    - Account
+    items:
+      type: string
+    title: The set of accounts that may be used for billing for this Encounter
+    type: array
+  actualPeriod:
+    description: '[Text representation of Period] The actual start and end time of
+      the encounter'
+    element_property: true
+    title: The actual start and end time of the encounter
+    type: string
+  admission:
+    description: '[Text representation of EncounterAdmission] Details about the stay
+      during which a healthcare service is provided.  This does not describe the event
+      of admitting the patient, but rather any information that is relevant from the
+      time of admittance until the time of discharge.'
+    element_property: true
+    title: Details about the admission to a healthcare service
+    type: string
+  appointment:
+    backref: appointment_encounter
+    description: '[Text representation of Reference] The appointment that scheduled
+      this encounter'
+    element_property: true
+    enum_reference_types:
+    - Appointment
+    items:
+      type: string
+    title: The appointment that scheduled this encounter
+    type: array
+  basedOn:
+    backref: basedOn_encounter
+    description: '[Text representation of Reference] The request this encounter satisfies
+      (e.g. incoming referral or procedure request).'
+    element_property: true
+    enum_reference_types:
+    - CarePlan
+    - DeviceRequest
+    - MedicationRequest
+    - ServiceRequest
+    items:
+      type: string
+    title: The request that initiated this encounter
+    type: array
+  careTeam:
+    backref: careTeam_encounter
+    description: '[Text representation of Reference] The group(s) of individuals,
+      organizations that are allocated to participate in this encounter. The participants
+      backbone will record the actuals of when these individuals participated during
+      the encounter.'
+    element_property: true
+    enum_reference_types:
+    - CareTeam
+    items:
+      type: string
+    title: The group(s) that are allocated to participate in this encounter
+    type: array
+  class_fhir:
+    binding_description: Classification of the encounter.
+    binding_strength: preferred
+    binding_uri: http://terminology.hl7.org/ValueSet/encounter-class
+    binding_version: null
+    description: text representation. Concepts representing classification of patient
+      encounter such as ambulatory (outpatient), inpatient, emergency, home health
+      or others due to local variations.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Classification of the encounter.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/encounter-class
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://terminology.hl7.org/ValueSet/encounter-class
+        term_url: http://terminology.hl7.org/ValueSet/encounter-class
+    title: Classification of patient encounter context - e.g. Inpatient, outpatient
+    type: array
+  class_fhir_coding: &id001
+    binding_description: Classification of the encounter.
+    binding_strength: preferred
+    binding_uri: http://terminology.hl7.org/ValueSet/encounter-class
+    binding_version: null
+    description: '[system#code representation.] Concepts representing classification
+      of patient encounter such as ambulatory (outpatient), inpatient, emergency,
+      home health or others due to local variations.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Classification of the encounter.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/encounter-class
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://terminology.hl7.org/ValueSet/encounter-class
+        term_url: http://terminology.hl7.org/ValueSet/encounter-class
+    title: Classification of patient encounter context - e.g. Inpatient, outpatient
+    type: array
+  class_fhir_text: *id001
+  diagnosis:
+    description: '[Text representation of EncounterDiagnosis] The list of diagnosis
+      relevant to this encounter'
+    element_property: true
+    items:
+      type: string
+    title: The list of diagnosis relevant to this encounter
+    type: array
+  dietPreference:
+    binding_description: Medical, cultural or ethical food preferences to help with
+      catering requirements.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-diet
+    binding_version: null
+    description: text representation. Diet preferences reported by the patient
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Medical, cultural or ethical food preferences to help with catering
+        requirements.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-diet
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/encounter-diet
+        term_url: http://hl7.org/fhir/ValueSet/encounter-diet
+    title: Diet preferences reported by the patient
+    type: array
+  dietPreference_coding: &id002
+    binding_description: Medical, cultural or ethical food preferences to help with
+      catering requirements.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-diet
+    binding_version: null
+    description: '[system#code representation.] Diet preferences reported by the patient'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Medical, cultural or ethical food preferences to help with catering
+        requirements.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-diet
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/encounter-diet
+        term_url: http://hl7.org/fhir/ValueSet/encounter-diet
+    title: Diet preferences reported by the patient
+    type: array
+  dietPreference_text: *id002
+  episodeOfCare:
+    backref: episodeOfCare_encounter
+    description: '[Text representation of Reference] Where a specific encounter should
+      be classified as a part of a specific episode(s) of care this field should be
+      used. This association can facilitate grouping of related encounters together
+      for a specific purpose, such as government reporting, issue tracking, association
+      via a common problem.  The association is recorded on the encounter as these
+      are typically created after the episode of care and grouped on entry rather
+      than editing the episode of care to append another encounter to it (the episode
+      of care could span years).'
+    element_property: true
+    enum_reference_types:
+    - EpisodeOfCare
+    items:
+      type: string
+    title: Episode(s) of care that this encounter should be recorded against
+    type: array
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Identifier(s) by which this encounter is known
+    element_property: true
+    items:
+      type: string
+    title: Identifier(s) by which this encounter is known
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Identifier(s) by which
+      this encounter is known'
+    element_property: true
+    items:
+      type: string
+    title: Identifier(s) by which this encounter is known
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Identifier(s) by
+      which this encounter is known'
+    element_property: true
+    items:
+      type: string
+    title: Identifier(s) by which this encounter is known
+    type: array
+  length:
+    description: '[Text representation of Duration] Actual quantity of time the encounter
+      lasted. This excludes the time during leaves of absence.  When missing it is
+      the time in between the start and end values.'
+    element_property: true
+    title: Actual quantity of time the encounter lasted (less time absent)
+    type: string
+  location:
+    description: '[Text representation of EncounterLocation] List of locations where  the
+      patient has been during this encounter.'
+    element_property: true
+    items:
+      type: string
+    title: List of locations where the patient has been
+    type: array
+  partOf:
+    backref: encounter
+    description: '[Text representation of Reference] Another Encounter of which this
+      encounter is a part of (administratively or in time).'
+    element_property: true
+    enum_reference_types:
+    - Encounter
+    title: Another Encounter this encounter is part of
+    type: string
+  participant:
+    description: '[Text representation of EncounterParticipant] The list of people
+      responsible for providing the service.'
+    element_property: true
+    items:
+      type: string
+    title: List of participants involved in the encounter
+    type: array
+  plannedEndDate:
+    description: The planned end date/time (or discharge date) of the encounter
+    element_property: true
+    format: date-time
+    title: The planned end date/time (or discharge date) of the encounter
+    type: string
+  plannedStartDate:
+    description: The planned start date/time (or admission date) of the encounter
+    element_property: true
+    format: date-time
+    title: The planned start date/time (or admission date) of the encounter
+    type: string
+  priority:
+    binding_description: Indicates the urgency of the encounter.
+    binding_strength: example
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-ActPriority
+    binding_version: null
+    description: text representation. Indicates the urgency of the encounter
+    element_property: true
+    term:
+      description: Indicates the urgency of the encounter.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-ActPriority
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://terminology.hl7.org/ValueSet/v3-ActPriority
+        term_url: http://terminology.hl7.org/ValueSet/v3-ActPriority
+    title: Indicates the urgency of the encounter
+    type: string
+  priority_coding: &id003
+    binding_description: Indicates the urgency of the encounter.
+    binding_strength: example
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-ActPriority
+    binding_version: null
+    description: '[system#code representation.] Indicates the urgency of the encounter'
+    element_property: true
+    term:
+      description: Indicates the urgency of the encounter.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-ActPriority
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://terminology.hl7.org/ValueSet/v3-ActPriority
+        term_url: http://terminology.hl7.org/ValueSet/v3-ActPriority
+    title: Indicates the urgency of the encounter
+    type: string
+  priority_text: *id003
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  reason:
+    description: '[Text representation of EncounterReason] The list of medical reasons
+      that are expected to be addressed during the episode of care'
+    element_property: true
+    items:
+      type: string
+    title: The list of medical reasons that are expected to be addressed during the
+      episode of care
+    type: array
+  resourceType:
+    const: Encounter
+    default: Encounter
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  serviceProvider:
+    backref: encounter
+    description: '[Text representation of Reference] The organization that is primarily
+      responsible for this Encounter''s services. This MAY be the same as the organization
+      on the Patient record, however it could be different, such as if the actor performing
+      the services was from an external organization (which may be billed seperately)
+      for an external consultation.  Refer to the colonoscopy example on the Encounter
+      examples tab.'
+    element_property: true
+    enum_reference_types:
+    - Organization
+    title: The organization (facility) responsible for this encounter
+    type: string
+  serviceType:
+    backref: serviceType_encounter
+    binding_description: Broad categorization of the service that is to be provided.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/service-type
+    binding_version: null
+    description: text representation. Broad categorization of the service that is
+      to be provided (e.g. cardiology).
+    element_property: true
+    enum_reference_types:
+    - HealthcareService
+    items:
+      type: string
+    term:
+      description: Broad categorization of the service that is to be provided.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/service-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/service-type
+        term_url: http://hl7.org/fhir/ValueSet/service-type
+    title: Specific type of service
+    type: array
+  serviceType_coding: &id004
+    backref: serviceType_encounter
+    binding_description: Broad categorization of the service that is to be provided.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/service-type
+    binding_version: null
+    description: '[system#code representation.] Broad categorization of the service
+      that is to be provided (e.g. cardiology).'
+    element_property: true
+    enum_reference_types:
+    - HealthcareService
+    items:
+      type: string
+    term:
+      description: Broad categorization of the service that is to be provided.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/service-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/service-type
+        term_url: http://hl7.org/fhir/ValueSet/service-type
+    title: Specific type of service
+    type: array
+  serviceType_text: *id004
+  specialArrangement:
+    binding_description: Special arrangements.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
+    binding_version: null
+    description: text representation. Any special requests that have been made for
+      this encounter, such as the provision of specific equipment or other things.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Special arrangements.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
+        term_url: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
+    title: Wheelchair, translator, stretcher, etc
+    type: array
+  specialArrangement_coding: &id005
+    binding_description: Special arrangements.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
+    binding_version: null
+    description: '[system#code representation.] Any special requests that have been
+      made for this encounter, such as the provision of specific equipment or other
+      things.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Special arrangements.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
+        term_url: http://hl7.org/fhir/ValueSet/encounter-special-arrangements
+    title: Wheelchair, translator, stretcher, etc
+    type: array
+  specialArrangement_text: *id005
+  specialCourtesy:
+    binding_description: Special courtesies.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
+    binding_version: null
+    description: text representation. Special courtesies that may be provided to the
+      patient during the encounter (VIP, board member, professional courtesy).
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Special courtesies.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
+        term_url: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
+    title: Special courtesies (VIP, board member)
+    type: array
+  specialCourtesy_coding: &id006
+    binding_description: Special courtesies.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
+    binding_version: null
+    description: '[system#code representation.] Special courtesies that may be provided
+      to the patient during the encounter (VIP, board member, professional courtesy).'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Special courtesies.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
+        term_url: http://hl7.org/fhir/ValueSet/encounter-special-courtesy
+    title: Special courtesies (VIP, board member)
+    type: array
+  specialCourtesy_text: *id006
+  status:
+    binding_description: Current state of the encounter.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-status
+    binding_version: 5.0.0
+    description: The current state of the encounter (not the state of the patient
+      within the encounter - that is subjectState).
+    element_property: true
+    element_required: true
+    enum_values:
+    - planned
+    - in-progress
+    - on-hold
+    - discharged
+    - completed
+    - cancelled
+    - discontinued
+    - entered-in-error
+    - unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: planned | in-progress | on-hold | discharged | completed | cancelled |
+      discontinued | entered-in-error | unknown
+    type: string
+  subject:
+    backref: encounter
+    description: '[Text representation of Reference] The patient or group related
+      to this encounter. In some use-cases the patient MAY not be present, such as
+      a case meeting about a patient between several practitioners or a careteam.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Group
+    title: The patient or group related to this encounter
+    type: string
+  subjectStatus:
+    binding_description: Current status of the subject  within the encounter.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-subject-status
+    binding_version: null
+    description: text representation. The subjectStatus value can be used to track
+      the patient's status within the encounter. It details whether the patient has
+      arrived or departed, has been triaged or is currently in a waiting status.
+    element_property: true
+    term:
+      description: Current status of the subject  within the encounter.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-subject-status
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/encounter-subject-status
+        term_url: http://hl7.org/fhir/ValueSet/encounter-subject-status
+    title: The current status of the subject in relation to the Encounter
+    type: string
+  subjectStatus_coding: &id007
+    binding_description: Current status of the subject  within the encounter.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-subject-status
+    binding_version: null
+    description: '[system#code representation.] The subjectStatus value can be used
+      to track the patient''s status within the encounter. It details whether the
+      patient has arrived or departed, has been triaged or is currently in a waiting
+      status.'
+    element_property: true
+    term:
+      description: Current status of the subject  within the encounter.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-subject-status
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/encounter-subject-status
+        term_url: http://hl7.org/fhir/ValueSet/encounter-subject-status
+    title: The current status of the subject in relation to the Encounter
+    type: string
+  subjectStatus_text: *id007
+  type:
+    binding_description: A specific code indicating type of service provided
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-type
+    binding_version: null
+    description: text representation. Specific type of encounter (e.g. e-mail consultation,
+      surgical day-care, skilled nursing, rehabilitation).
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A specific code indicating type of service provided
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/encounter-type
+        term_url: http://hl7.org/fhir/ValueSet/encounter-type
+    title: Specific type of encounter (e.g. e-mail consultation, surgical day-care,
+      ...)
+    type: array
+  type_coding: &id008
+    binding_description: A specific code indicating type of service provided
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/encounter-type
+    binding_version: null
+    description: '[system#code representation.] Specific type of encounter (e.g. e-mail
+      consultation, surgical day-care, skilled nursing, rehabilitation).'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A specific code indicating type of service provided
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/encounter-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/encounter-type
+        term_url: http://hl7.org/fhir/ValueSet/encounter-type
+    title: Specific type of encounter (e.g. e-mail consultation, surgical day-care,
+      ...)
+    type: array
+  type_text: *id008
+  virtualService:
+    description: '[Text representation of VirtualServiceDetail] Connection details
+      of a virtual service (e.g. conference call)'
+    element_property: true
+    items:
+      type: string
+    title: Connection details of a virtual service (e.g. conference call)
+    type: array
+title: Encounter
+type: object

--- a/tests/integration/data/schemas/family_member_history.yaml
+++ b/tests/integration/data/schemas/family_member_history.yaml
@@ -1,0 +1,488 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: Information about patient's relatives, relevant for patient. Significant
+  health conditions for a person related to the patient relevant in the context of
+  care for the patient. [See https://hl7.org/fhir/R5/FamilyMemberHistory.html]
+id: family_member_history
+links:
+- backref: family_member_history
+  label: FamilyMemberHistory_patient_Patient_family_member_history
+  multiplicity: many_to_many
+  name: patient
+  required: false
+  target_type: patient
+- backref: reason_family_member_history
+  label: FamilyMemberHistory_reason_Condition_reason_family_member_history
+  multiplicity: many_to_many
+  name: reason_Condition
+  required: false
+  target_type: condition
+- backref: reason_family_member_history
+  label: FamilyMemberHistory_reason_Observation_reason_family_member_history
+  multiplicity: many_to_many
+  name: reason_Observation
+  required: false
+  target_type: observation
+- backref: reason_family_member_history
+  label: FamilyMemberHistory_reason_DiagnosticReport_reason_family_member_history
+  multiplicity: many_to_many
+  name: reason_DiagnosticReport
+  required: false
+  target_type: diagnostic_report
+- backref: reason_family_member_history
+  label: FamilyMemberHistory_reason_DocumentReference_reason_family_member_history
+  multiplicity: many_to_many
+  name: reason_DocumentReference
+  required: false
+  target_type: document_reference
+program: '*'
+project: '*'
+properties:
+  ageAge:
+    description: '[Text representation of Age] The age of the relative at the time
+      the family member history is recorded.'
+    element_property: true
+    one_of_many: age
+    one_of_many_required: false
+    title: (approximate) age
+    type: string
+  ageRange:
+    description: '[Text representation of Range] The age of the relative at the time
+      the family member history is recorded.'
+    element_property: true
+    one_of_many: age
+    one_of_many_required: false
+    title: (approximate) age
+    type: string
+  ageString:
+    description: The age of the relative at the time the family member history is
+      recorded.
+    element_property: true
+    one_of_many: age
+    one_of_many_required: false
+    pattern: '[ \r\n\t\S]+'
+    title: (approximate) age
+    type: string
+  bornDate:
+    description: The actual or approximate date of birth of the relative.
+    element_property: true
+    format: date
+    one_of_many: born
+    one_of_many_required: false
+    title: (approximate) date of birth
+    type: string
+  bornPeriod:
+    description: '[Text representation of Period] The actual or approximate date of
+      birth of the relative.'
+    element_property: true
+    one_of_many: born
+    one_of_many_required: false
+    title: (approximate) date of birth
+    type: string
+  bornString:
+    description: The actual or approximate date of birth of the relative.
+    element_property: true
+    one_of_many: born
+    one_of_many_required: false
+    pattern: '[ \r\n\t\S]+'
+    title: (approximate) date of birth
+    type: string
+  condition:
+    description: '[Text representation of FamilyMemberHistoryCondition] The significant
+      Conditions (or condition) that the family member had. This is a repeating section
+      to allow a system to represent more than one condition per resource, though
+      there is nothing stopping multiple resources - one per condition.'
+    element_property: true
+    items:
+      type: string
+    title: Condition that the related person had
+    type: array
+  dataAbsentReason:
+    binding_description: Codes describing the reason why a family member's history
+      is not available.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/history-absent-reason
+    binding_version: null
+    description: text representation. Describes why the family member's history is
+      not available.
+    element_property: true
+    term:
+      description: Codes describing the reason why a family member's history is not
+        available.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/history-absent-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/history-absent-reason
+        term_url: http://hl7.org/fhir/ValueSet/history-absent-reason
+    title: subject-unknown | withheld | unable-to-obtain | deferred
+    type: string
+  dataAbsentReason_coding: &id001
+    binding_description: Codes describing the reason why a family member's history
+      is not available.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/history-absent-reason
+    binding_version: null
+    description: '[system#code representation.] Describes why the family member''s
+      history is not available.'
+    element_property: true
+    term:
+      description: Codes describing the reason why a family member's history is not
+        available.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/history-absent-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/history-absent-reason
+        term_url: http://hl7.org/fhir/ValueSet/history-absent-reason
+    title: subject-unknown | withheld | unable-to-obtain | deferred
+    type: string
+  dataAbsentReason_text: *id001
+  date:
+    description: The date (and possibly time) when the family member history was recorded
+      or last updated.
+    element_property: true
+    format: date-time
+    title: When history was recorded or last updated
+    type: string
+  deceasedAge:
+    description: '[Text representation of Age] Deceased flag or the actual or approximate
+      age of the relative at the time of death for the family member history record.'
+    element_property: true
+    one_of_many: deceased
+    one_of_many_required: false
+    title: Dead? How old/when?
+    type: string
+  deceasedBoolean:
+    description: Deceased flag or the actual or approximate age of the relative at
+      the time of death for the family member history record.
+    element_property: true
+    one_of_many: deceased
+    one_of_many_required: false
+    title: Dead? How old/when?
+    type: boolean
+  deceasedDate:
+    description: Deceased flag or the actual or approximate age of the relative at
+      the time of death for the family member history record.
+    element_property: true
+    format: date
+    one_of_many: deceased
+    one_of_many_required: false
+    title: Dead? How old/when?
+    type: string
+  deceasedRange:
+    description: '[Text representation of Range] Deceased flag or the actual or approximate
+      age of the relative at the time of death for the family member history record.'
+    element_property: true
+    one_of_many: deceased
+    one_of_many_required: false
+    title: Dead? How old/when?
+    type: string
+  deceasedString:
+    description: Deceased flag or the actual or approximate age of the relative at
+      the time of death for the family member history record.
+    element_property: true
+    one_of_many: deceased
+    one_of_many_required: false
+    pattern: '[ \r\n\t\S]+'
+    title: Dead? How old/when?
+    type: string
+  estimatedAge:
+    description: If true, indicates that the age value specified is an estimated value.
+    element_property: true
+    title: Age is estimated?
+    type: boolean
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Business identifiers assigned to this family member history by the
+      performer or other systems which remain constant as the resource is updated
+      and propagates from server to server.
+    element_property: true
+    items:
+      type: string
+    title: External Id(s) for this record
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Business identifiers
+      assigned to this family member history by the performer or other systems which
+      remain constant as the resource is updated and propagates from server to server.'
+    element_property: true
+    items:
+      type: string
+    title: External Id(s) for this record
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Business identifiers
+      assigned to this family member history by the performer or other systems which
+      remain constant as the resource is updated and propagates from server to server.'
+    element_property: true
+    items:
+      type: string
+    title: External Id(s) for this record
+    type: array
+  instantiatesCanonical:
+    description: The URL pointing to a FHIR-defined protocol, guideline, orderset
+      or other definition that is adhered to in whole or in part by this FamilyMemberHistory.
+    element_property: true
+    enum_reference_types:
+    - PlanDefinition
+    - Questionnaire
+    - ActivityDefinition
+    - Measure
+    - OperationDefinition
+    items:
+      pattern: \S*
+      type: string
+    title: Instantiates FHIR protocol or definition
+    type: array
+  instantiatesUri:
+    description: The URL pointing to an externally maintained protocol, guideline,
+      orderset or other definition that is adhered to in whole or in part by this
+      FamilyMemberHistory.
+    element_property: true
+    items:
+      pattern: \S*
+      type: string
+    title: Instantiates external protocol or definition
+    type: array
+  name:
+    description: This will either be a name or a description; e.g. "Aunt Susan", "my
+      cousin with the red hair".
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: The family member described
+    type: string
+  note:
+    description: '[Text representation of Annotation] This property allows a non condition-specific
+      note to the made about the related person. Ideally, the note would be in the
+      condition property, but this is not always possible.'
+    element_property: true
+    items:
+      type: string
+    title: General note about related person
+    type: array
+  participant:
+    description: '[Text representation of FamilyMemberHistoryParticipant] Indicates
+      who or what participated in the activities related to the family member history
+      and how they were involved.'
+    element_property: true
+    items:
+      type: string
+    title: Who or what participated in the activities related to the family member
+      history and how they were involved
+    type: array
+  patient:
+    backref: family_member_history
+    description: '[Text representation of Reference] The person who this history concerns.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    title: Patient history is about
+    type: string
+  procedure:
+    description: '[Text representation of FamilyMemberHistoryProcedure] The significant
+      Procedures (or procedure) that the family member had. This is a repeating section
+      to allow a system to represent more than one procedure per resource, though
+      there is nothing stopping multiple resources - one per procedure.'
+    element_property: true
+    items:
+      type: string
+    title: Procedures that the related person had
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  reason:
+    backref: reason_family_member_history
+    binding_description: Codes indicating why the family member history was done.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/clinical-findings
+    binding_version: null
+    description: text representation. Describes why the family member history occurred
+      in coded or textual form, or Indicates a Condition, Observation, AllergyIntolerance,
+      or QuestionnaireResponse that justifies this family member history event.
+    element_property: true
+    enum_reference_types:
+    - Condition
+    - Observation
+    - AllergyIntolerance
+    - QuestionnaireResponse
+    - DiagnosticReport
+    - DocumentReference
+    items:
+      type: string
+    term:
+      description: Codes indicating why the family member history was done.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/clinical-findings
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/clinical-findings
+        term_url: http://hl7.org/fhir/ValueSet/clinical-findings
+    title: Why was family member history performed?
+    type: array
+  reason_coding: &id002
+    backref: reason_family_member_history
+    binding_description: Codes indicating why the family member history was done.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/clinical-findings
+    binding_version: null
+    description: '[system#code representation.] Describes why the family member history
+      occurred in coded or textual form, or Indicates a Condition, Observation, AllergyIntolerance,
+      or QuestionnaireResponse that justifies this family member history event.'
+    element_property: true
+    enum_reference_types:
+    - Condition
+    - Observation
+    - AllergyIntolerance
+    - QuestionnaireResponse
+    - DiagnosticReport
+    - DocumentReference
+    items:
+      type: string
+    term:
+      description: Codes indicating why the family member history was done.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/clinical-findings
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/clinical-findings
+        term_url: http://hl7.org/fhir/ValueSet/clinical-findings
+    title: Why was family member history performed?
+    type: array
+  reason_text: *id002
+  relationship:
+    binding_description: The nature of the relationship between the patient and the
+      related person being described in the family member history.
+    binding_strength: example
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-FamilyMember
+    binding_version: null
+    description: text representation. The type of relationship this person has to
+      the patient (father, mother, brother etc.).
+    element_property: true
+    term:
+      description: The nature of the relationship between the patient and the related
+        person being described in the family member history.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-FamilyMember
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://terminology.hl7.org/ValueSet/v3-FamilyMember
+        term_url: http://terminology.hl7.org/ValueSet/v3-FamilyMember
+    title: Relationship to the subject
+    type: string
+  relationship_coding: &id003
+    binding_description: The nature of the relationship between the patient and the
+      related person being described in the family member history.
+    binding_strength: example
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-FamilyMember
+    binding_version: null
+    description: '[system#code representation.] The type of relationship this person
+      has to the patient (father, mother, brother etc.).'
+    element_property: true
+    term:
+      description: The nature of the relationship between the patient and the related
+        person being described in the family member history.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-FamilyMember
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://terminology.hl7.org/ValueSet/v3-FamilyMember
+        term_url: http://terminology.hl7.org/ValueSet/v3-FamilyMember
+    title: Relationship to the subject
+    type: string
+  relationship_text: *id003
+  resourceType:
+    const: FamilyMemberHistory
+    default: FamilyMemberHistory
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  sex:
+    binding_description: Codes describing the sex assigned at birth as documented
+      on the birth registration.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/administrative-gender
+    binding_version: null
+    description: text representation. The birth sex of the family member.
+    element_property: true
+    term:
+      description: Codes describing the sex assigned at birth as documented on the
+        birth registration.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/administrative-gender
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/administrative-gender
+        term_url: http://hl7.org/fhir/ValueSet/administrative-gender
+    title: male | female | other | unknown
+    type: string
+  sex_coding: &id004
+    binding_description: Codes describing the sex assigned at birth as documented
+      on the birth registration.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/administrative-gender
+    binding_version: null
+    description: '[system#code representation.] The birth sex of the family member.'
+    element_property: true
+    term:
+      description: Codes describing the sex assigned at birth as documented on the
+        birth registration.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/administrative-gender
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/administrative-gender
+        term_url: http://hl7.org/fhir/ValueSet/administrative-gender
+    title: male | female | other | unknown
+    type: string
+  sex_text: *id004
+  status:
+    binding_description: A code that identifies the status of the family history record.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/history-status
+    binding_version: 5.0.0
+    description: A code specifying the status of the record of the family history
+      of a specific family member.
+    element_property: true
+    element_required: true
+    enum_values:
+    - partial
+    - completed
+    - entered-in-error
+    - health-unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: partial | completed | entered-in-error | health-unknown
+    type: string
+title: FamilyMemberHistory
+type: object

--- a/tests/integration/data/schemas/immunization.yaml
+++ b/tests/integration/data/schemas/immunization.yaml
@@ -1,0 +1,687 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: Immunization event information. Describes the event of a patient being
+  administered a vaccine or a record of an immunization as reported by a patient,
+  a clinician or another party. [See https://hl7.org/fhir/R5/Immunization.html]
+id: immunization
+links:
+- backref: immunization
+  label: Immunization_administeredProduct_Medication_immunization
+  multiplicity: many_to_many
+  name: administeredProduct
+  required: false
+  target_type: medication
+- backref: immunization
+  label: Immunization_encounter_Encounter_immunization
+  multiplicity: many_to_many
+  name: encounter
+  required: false
+  target_type: encounter
+- backref: informationSource_immunization
+  label: Immunization_informationSource_Patient_informationSource_immunization
+  multiplicity: many_to_many
+  name: informationSource_Patient
+  required: false
+  target_type: patient
+- backref: informationSource_immunization
+  label: Immunization_informationSource_Practitioner_informationSource_immunization
+  multiplicity: many_to_many
+  name: informationSource_Practitioner
+  required: false
+  target_type: practitioner
+- backref: informationSource_immunization
+  label: Immunization_informationSource_PractitionerRole_informationSource_immunization
+  multiplicity: many_to_many
+  name: informationSource_PractitionerRole
+  required: false
+  target_type: practitioner_role
+- backref: informationSource_immunization
+  label: Immunization_informationSource_Organization_informationSource_immunization
+  multiplicity: many_to_many
+  name: informationSource_Organization
+  required: false
+  target_type: organization
+- backref: immunization
+  label: Immunization_location_Location_immunization
+  multiplicity: many_to_many
+  name: location
+  required: false
+  target_type: location
+- backref: reason_immunization
+  label: Immunization_reason_Condition_reason_immunization
+  multiplicity: many_to_many
+  name: reason_Condition
+  required: false
+  target_type: condition
+- backref: reason_immunization
+  label: Immunization_reason_Observation_reason_immunization
+  multiplicity: many_to_many
+  name: reason_Observation
+  required: false
+  target_type: observation
+- backref: reason_immunization
+  label: Immunization_reason_DiagnosticReport_reason_immunization
+  multiplicity: many_to_many
+  name: reason_DiagnosticReport
+  required: false
+  target_type: diagnostic_report
+program: '*'
+project: '*'
+properties:
+  administeredProduct:
+    backref: immunization
+    description: text representation. An indication of which product was administered
+      to the patient. This is typically a more detailed representation of the concept
+      conveyed by the vaccineCode data element. If a Medication resource is referenced,
+      it may be to a stand-alone resource or a contained resource within the Immunization
+      resource.
+    element_property: true
+    enum_reference_types:
+    - Medication
+    title: Product that was administered
+    type: string
+  administeredProduct_coding: &id001
+    backref: immunization
+    description: '[system#code representation.] An indication of which product was
+      administered to the patient. This is typically a more detailed representation
+      of the concept conveyed by the vaccineCode data element. If a Medication resource
+      is referenced, it may be to a stand-alone resource or a contained resource within
+      the Immunization resource.'
+    element_property: true
+    enum_reference_types:
+    - Medication
+    title: Product that was administered
+    type: string
+  administeredProduct_text: *id001
+  basedOn:
+    backref: basedOn_immunization
+    description: '[Text representation of Reference] A plan, order or recommendation
+      fulfilled in whole or in part by this immunization.'
+    element_property: true
+    enum_reference_types:
+    - CarePlan
+    - MedicationRequest
+    - ServiceRequest
+    - ImmunizationRecommendation
+    items:
+      type: string
+    title: Authority that the immunization event is based on
+    type: array
+  doseQuantity:
+    description: '[Text representation of Quantity] text representation. The quantity
+      of vaccine product that was administered.'
+    element_property: true
+    title: Amount of vaccine administered
+    type: string
+  doseQuantity_unit:
+    title: Unit representation. Amount of vaccine administered
+    type: string
+  doseQuantity_value:
+    title: Numerical value (with implicit precision) representation. Amount of vaccine
+      administered
+    type: number
+  encounter:
+    backref: immunization
+    description: '[Text representation of Reference] The visit or admission or other
+      contact between patient and health care provider the immunization was performed
+      as part of.'
+    element_property: true
+    enum_reference_types:
+    - Encounter
+    title: Encounter immunization was part of
+    type: string
+  expirationDate:
+    description: Date vaccine batch expires.
+    element_property: true
+    format: date
+    title: Vaccine expiration date
+    type: string
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  fundingSource:
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-funding-source
+    binding_version: null
+    description: text representation. Indicates the source of the vaccine actually
+      administered. This may be different than the patient eligibility (e.g. the patient
+      may be eligible for a publically purchased vaccine but due to inventory issues,
+      vaccine purchased with private funds was actually administered).
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-funding-source
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-funding-source
+        term_url: http://hl7.org/fhir/ValueSet/immunization-funding-source
+    title: Funding source for the vaccine
+    type: string
+  fundingSource_coding: &id002
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-funding-source
+    binding_version: null
+    description: '[system#code representation.] Indicates the source of the vaccine
+      actually administered. This may be different than the patient eligibility (e.g.
+      the patient may be eligible for a publically purchased vaccine but due to inventory
+      issues, vaccine purchased with private funds was actually administered).'
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-funding-source
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-funding-source
+        term_url: http://hl7.org/fhir/ValueSet/immunization-funding-source
+    title: Funding source for the vaccine
+    type: string
+  fundingSource_text: *id002
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: A unique identifier assigned to this immunization record.
+    element_property: true
+    items:
+      type: string
+    title: Business identifier
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] A unique identifier assigned
+      to this immunization record.'
+    element_property: true
+    items:
+      type: string
+    title: Business identifier
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] A unique identifier
+      assigned to this immunization record.'
+    element_property: true
+    items:
+      type: string
+    title: Business identifier
+    type: array
+  informationSource:
+    backref: informationSource_immunization
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-origin
+    binding_version: null
+    description: text representation. Typically the source of the data when the report
+      of the immunization event is not based on information from the person who administered
+      the vaccine.
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Practitioner
+    - PractitionerRole
+    - RelatedPerson
+    - Organization
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-origin
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-origin
+        term_url: http://hl7.org/fhir/ValueSet/immunization-origin
+    title: Indicates the source of a  reported record
+    type: string
+  informationSource_coding: &id003
+    backref: informationSource_immunization
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-origin
+    binding_version: null
+    description: '[system#code representation.] Typically the source of the data when
+      the report of the immunization event is not based on information from the person
+      who administered the vaccine.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Practitioner
+    - PractitionerRole
+    - RelatedPerson
+    - Organization
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-origin
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-origin
+        term_url: http://hl7.org/fhir/ValueSet/immunization-origin
+    title: Indicates the source of a  reported record
+    type: string
+  informationSource_text: *id003
+  isSubpotent:
+    description: Indication if a dose is considered to be subpotent. By default, a
+      dose should be considered to be potent.
+    element_property: true
+    title: Dose potency
+    type: boolean
+  location:
+    backref: immunization
+    description: '[Text representation of Reference] The service delivery location
+      where the vaccine administration occurred.'
+    element_property: true
+    enum_reference_types:
+    - Location
+    title: Where immunization occurred
+    type: string
+  lotNumber:
+    description: Lot number of the  vaccine product.
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: Vaccine lot number
+    type: string
+  manufacturer:
+    backref: manufacturer_immunization
+    description: text representation. Name of vaccine manufacturer.
+    element_property: true
+    enum_reference_types:
+    - Organization
+    title: Vaccine manufacturer
+    type: string
+  manufacturer_coding: &id004
+    backref: manufacturer_immunization
+    description: '[system#code representation.] Name of vaccine manufacturer.'
+    element_property: true
+    enum_reference_types:
+    - Organization
+    title: Vaccine manufacturer
+    type: string
+  manufacturer_text: *id004
+  note:
+    description: '[Text representation of Annotation] Extra information about the
+      immunization that is not conveyed by the other attributes.'
+    element_property: true
+    items:
+      type: string
+    title: Additional immunization notes
+    type: array
+  occurrenceDateTime:
+    description: Date vaccine administered or was to be administered.
+    element_property: true
+    format: date-time
+    one_of_many: occurrence
+    one_of_many_required: true
+    title: Vaccine administration date
+    type: string
+  occurrenceString:
+    description: Date vaccine administered or was to be administered.
+    element_property: true
+    one_of_many: occurrence
+    one_of_many_required: true
+    pattern: '[ \r\n\t\S]+'
+    title: Vaccine administration date
+    type: string
+  patient:
+    backref: patient_immunization
+    description: '[Text representation of Reference] The patient who either received
+      or did not receive the immunization.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    title: Who was immunized
+    type: string
+  performer:
+    description: '[Text representation of ImmunizationPerformer] Indicates who performed
+      the immunization event.'
+    element_property: true
+    items:
+      type: string
+    title: Who performed event
+    type: array
+  primarySource:
+    description: Indicates whether the data contained in the resource was captured
+      by the individual/organization which was responsible for the administration
+      of the vaccine rather than as 'secondary reported' data documented by a third
+      party. A value of 'true' means this data originated with the individual/organization
+      which was responsible for the administration of the vaccine.
+    element_property: true
+    title: Indicates context the data was captured in
+    type: boolean
+  programEligibility:
+    description: '[Text representation of ImmunizationProgramEligibility] Indicates
+      a patient''s eligibility for a funding program.'
+    element_property: true
+    items:
+      type: string
+    title: Patient eligibility for a specific vaccination program
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  protocolApplied:
+    description: '[Text representation of ImmunizationProtocolApplied] The protocol
+      (set of recommendations) being followed by the provider who administered the
+      dose.'
+    element_property: true
+    items:
+      type: string
+    title: Protocol followed by the provider
+    type: array
+  reaction:
+    description: '[Text representation of ImmunizationReaction] Categorical data indicating
+      that an adverse event is associated in time to an immunization.'
+    element_property: true
+    items:
+      type: string
+    title: Details of a reaction that follows immunization
+    type: array
+  reason:
+    backref: reason_immunization
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-reason
+    binding_version: null
+    description: text representation. Describes why the immunization occurred in coded
+      or textual form, or Indicates another resource (Condition, Observation or DiagnosticReport)
+      whose existence justifies this immunization.
+    element_property: true
+    enum_reference_types:
+    - Condition
+    - Observation
+    - DiagnosticReport
+    items:
+      type: string
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-reason
+        term_url: http://hl7.org/fhir/ValueSet/immunization-reason
+    title: Why immunization occurred
+    type: array
+  reason_coding: &id005
+    backref: reason_immunization
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-reason
+    binding_version: null
+    description: '[system#code representation.] Describes why the immunization occurred
+      in coded or textual form, or Indicates another resource (Condition, Observation
+      or DiagnosticReport) whose existence justifies this immunization.'
+    element_property: true
+    enum_reference_types:
+    - Condition
+    - Observation
+    - DiagnosticReport
+    items:
+      type: string
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-reason
+        term_url: http://hl7.org/fhir/ValueSet/immunization-reason
+    title: Why immunization occurred
+    type: array
+  reason_text: *id005
+  resourceType:
+    const: Immunization
+    default: Immunization
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  route:
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-route
+    binding_version: null
+    description: text representation. The path by which the vaccine product is taken
+      into the body.
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-route
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-route
+        term_url: http://hl7.org/fhir/ValueSet/immunization-route
+    title: How vaccine entered body
+    type: string
+  route_coding: &id006
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-route
+    binding_version: null
+    description: '[system#code representation.] The path by which the vaccine product
+      is taken into the body.'
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-route
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-route
+        term_url: http://hl7.org/fhir/ValueSet/immunization-route
+    title: How vaccine entered body
+    type: string
+  route_text: *id006
+  site:
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-site
+    binding_version: null
+    description: text representation. Body site where vaccine was administered.
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-site
+        term_url: http://hl7.org/fhir/ValueSet/immunization-site
+    title: Body site vaccine  was administered
+    type: string
+  site_coding: &id007
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-site
+    binding_version: null
+    description: '[system#code representation.] Body site where vaccine was administered.'
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-site
+        term_url: http://hl7.org/fhir/ValueSet/immunization-site
+    title: Body site vaccine  was administered
+    type: string
+  site_text: *id007
+  status:
+    binding_description: x
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-status
+    binding_version: 5.0.0
+    description: Indicates the current status of the immunization event.
+    element_property: true
+    element_required: true
+    enum_values:
+    - completed
+    - entered-in-error
+    - not-done
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: completed | entered-in-error | not-done
+    type: string
+  statusReason:
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-status-reason
+    binding_version: null
+    description: text representation. Indicates the reason the immunization event
+      was not performed.
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-status-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-status-reason
+        term_url: http://hl7.org/fhir/ValueSet/immunization-status-reason
+    title: Reason for current status
+    type: string
+  statusReason_coding: &id008
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-status-reason
+    binding_version: null
+    description: '[system#code representation.] Indicates the reason the immunization
+      event was not performed.'
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-status-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-status-reason
+        term_url: http://hl7.org/fhir/ValueSet/immunization-status-reason
+    title: Reason for current status
+    type: string
+  statusReason_text: *id008
+  subpotentReason:
+    binding_description: The reason why a dose is considered to be subpotent.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
+    binding_version: null
+    description: text representation. Reason why a dose is considered to be subpotent.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: The reason why a dose is considered to be subpotent.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
+        term_url: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
+    title: Reason for being subpotent
+    type: array
+  subpotentReason_coding: &id009
+    binding_description: The reason why a dose is considered to be subpotent.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
+    binding_version: null
+    description: '[system#code representation.] Reason why a dose is considered to
+      be subpotent.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: The reason why a dose is considered to be subpotent.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
+        term_url: http://hl7.org/fhir/ValueSet/immunization-subpotent-reason
+    title: Reason for being subpotent
+    type: array
+  subpotentReason_text: *id009
+  supportingInformation:
+    backref: supportingInformation_immunization
+    description: '[Text representation of Reference] Additional information that is
+      relevant to the immunization (e.g. for a vaccine recipient who is pregnant,
+      the gestational age of the fetus). The reason why a vaccine was given (e.g.
+      occupation, underlying medical condition) should be conveyed in Immunization.reason,
+      not as supporting information. The reason why a vaccine was not given (e.g.
+      contraindication) should be conveyed in Immunization.statusReason, not as supporting
+      information.'
+    element_property: true
+    enum_reference_types:
+    - Resource
+    items:
+      type: string
+    title: Additional information in support of the immunization
+    type: array
+  vaccineCode:
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/vaccine-code
+    binding_version: null
+    description: text representation. Vaccine that was administered or was to be administered.
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/vaccine-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/vaccine-code
+        term_url: http://hl7.org/fhir/ValueSet/vaccine-code
+    title: Vaccine administered
+    type: string
+  vaccineCode_coding: &id010
+    binding_description: x
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/vaccine-code
+    binding_version: null
+    description: '[system#code representation.] Vaccine that was administered or was
+      to be administered.'
+    element_property: true
+    term:
+      description: x
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/vaccine-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/vaccine-code
+        term_url: http://hl7.org/fhir/ValueSet/vaccine-code
+    title: Vaccine administered
+    type: string
+  vaccineCode_text: *id010
+title: Immunization
+type: object

--- a/tests/integration/data/schemas/location.yaml
+++ b/tests/integration/data/schemas/location.yaml
@@ -1,0 +1,342 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Administrative
+description: Details and position information for a place. Details and position information
+  for a place where services are provided and resources and participants may be stored,
+  found, contained, or accommodated. [See https://hl7.org/fhir/R5/Location.html]
+id: location
+links:
+- backref: location
+  label: Location_managingOrganization_Organization_location
+  multiplicity: many_to_many
+  name: managingOrganization
+  required: false
+  target_type: organization
+- backref: location
+  label: Location_partOf_Location_location
+  multiplicity: many_to_many
+  name: partOf
+  required: false
+  target_type: location
+program: '*'
+project: '*'
+properties:
+  address:
+    description: '[Text representation of Address] Physical location'
+    element_property: true
+    title: Physical location
+    type: string
+  alias:
+    description: A list of alternate names that the location is known as, or was known
+      as, in the past
+    element_property: true
+    items:
+      pattern: '[ \r\n\t\S]+'
+      type: string
+    title: A list of alternate names that the location is known as, or was known as,
+      in the past
+    type: array
+  characteristic:
+    binding_description: A custom attribute that could be provided at a service (e.g.
+      Wheelchair accessibiliy).
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/location-characteristic
+    binding_version: null
+    description: text representation. Collection of characteristics (attributes)
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A custom attribute that could be provided at a service (e.g. Wheelchair
+        accessibiliy).
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/location-characteristic
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/location-characteristic
+        term_url: http://hl7.org/fhir/ValueSet/location-characteristic
+    title: Collection of characteristics (attributes)
+    type: array
+  characteristic_coding: &id001
+    binding_description: A custom attribute that could be provided at a service (e.g.
+      Wheelchair accessibiliy).
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/location-characteristic
+    binding_version: null
+    description: '[system#code representation.] Collection of characteristics (attributes)'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A custom attribute that could be provided at a service (e.g. Wheelchair
+        accessibiliy).
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/location-characteristic
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/location-characteristic
+        term_url: http://hl7.org/fhir/ValueSet/location-characteristic
+    title: Collection of characteristics (attributes)
+    type: array
+  characteristic_text: *id001
+  contact:
+    description: '[Text representation of ExtendedContactDetail] The contact details
+      of communication devices available at the location. This can include addresses,
+      phone numbers, fax numbers, mobile numbers, email addresses and web sites.'
+    element_property: true
+    items:
+      type: string
+    title: Official contact details for the location
+    type: array
+  description:
+    description: Description of the Location, which helps in finding or referencing
+      the place.
+    element_property: true
+    pattern: \s*(\S|\s)*
+    title: Additional details about the location that could be displayed as further
+      information to identify the location beyond its name
+    type: string
+  endpoint:
+    backref: endpoint_location
+    description: '[Text representation of Reference] Technical endpoints providing
+      access to services operated for the location'
+    element_property: true
+    enum_reference_types:
+    - Endpoint
+    items:
+      type: string
+    title: Technical endpoints providing access to services operated for the location
+    type: array
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  form:
+    binding_description: Physical form of the location.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/location-form
+    binding_version: null
+    description: text representation. Physical form of the location, e.g. building,
+      room, vehicle, road, virtual.
+    element_property: true
+    term:
+      description: Physical form of the location.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/location-form
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/location-form
+        term_url: http://hl7.org/fhir/ValueSet/location-form
+    title: Physical form of the location
+    type: string
+  form_coding: &id002
+    binding_description: Physical form of the location.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/location-form
+    binding_version: null
+    description: '[system#code representation.] Physical form of the location, e.g.
+      building, room, vehicle, road, virtual.'
+    element_property: true
+    term:
+      description: Physical form of the location.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/location-form
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/location-form
+        term_url: http://hl7.org/fhir/ValueSet/location-form
+    title: Physical form of the location
+    type: string
+  form_text: *id002
+  hoursOfOperation:
+    description: '[Text representation of Availability] What days/times during a week
+      is this location usually open, and any exceptions where the location is not
+      available.'
+    element_property: true
+    items:
+      type: string
+    title: What days/times during a week is this location usually open (including
+      exceptions)
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Unique code or number identifying the location to its users
+    element_property: true
+    items:
+      type: string
+    title: Unique code or number identifying the location to its users
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Unique code or number
+      identifying the location to its users'
+    element_property: true
+    items:
+      type: string
+    title: Unique code or number identifying the location to its users
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Unique code or number
+      identifying the location to its users'
+    element_property: true
+    items:
+      type: string
+    title: Unique code or number identifying the location to its users
+    type: array
+  managingOrganization:
+    backref: location
+    description: '[Text representation of Reference] The organization responsible
+      for the provisioning and upkeep of the location.'
+    element_property: true
+    enum_reference_types:
+    - Organization
+    title: Organization responsible for provisioning and upkeep
+    type: string
+  mode:
+    binding_description: Indicates whether a resource instance represents a specific
+      location or a class of locations.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/location-mode
+    binding_version: 5.0.0
+    description: Indicates whether a resource instance represents a specific location
+      or a class of locations.
+    element_property: true
+    enum_values:
+    - instance
+    - kind
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: instance | kind
+    type: string
+  name:
+    description: Name of the location as used by humans. Does not need to be unique.
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: Name of the location as used by humans
+    type: string
+  operationalStatus:
+    binding_description: The operational status if the location (where typically a
+      bed/room).
+    binding_strength: preferred
+    binding_uri: http://terminology.hl7.org/ValueSet/v2-0116
+    binding_version: null
+    description: '[Text representation of Coding] The operational status covers operation
+      values most relevant to beds (but can also apply to rooms/units/chairs/etc.
+      such as an isolation unit/dialysis chair). This typically covers concepts such
+      as contamination, housekeeping, and other activities like maintenance.'
+    element_property: true
+    title: The operational status of the location (typically only for a bed/room)
+    type: string
+  partOf:
+    backref: location
+    description: '[Text representation of Reference] Another Location of which this
+      Location is physically a part of.'
+    element_property: true
+    enum_reference_types:
+    - Location
+    title: Another Location this one is physically a part of
+    type: string
+  position:
+    description: '[Text representation of LocationPosition] The absolute geographic
+      location of the Location, expressed using the WGS84 datum (This is the same
+      co-ordinate system used in KML).'
+    element_property: true
+    title: The absolute geographic location
+    type: string
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  resourceType:
+    const: Location
+    default: Location
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  status:
+    binding_description: Indicates whether the location is still in use.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/location-status
+    binding_version: 5.0.0
+    description: The status property covers the general availability of the resource,
+      not the current value which may be covered by the operationStatus, or by a schedule/slots
+      if they are configured for the location.
+    element_property: true
+    enum_values:
+    - active
+    - suspended
+    - inactive
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: active | suspended | inactive
+    type: string
+  type:
+    binding_description: Indicates the type of function performed at the location.
+    binding_strength: extensible
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
+    binding_version: null
+    description: text representation. Indicates the type of function performed at
+      the location.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Indicates the type of function performed at the location.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
+        term_url: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
+    title: Type of function performed
+    type: array
+  type_coding: &id003
+    binding_description: Indicates the type of function performed at the location.
+    binding_strength: extensible
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
+    binding_version: null
+    description: '[system#code representation.] Indicates the type of function performed
+      at the location.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Indicates the type of function performed at the location.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
+        term_url: http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType
+    title: Type of function performed
+    type: array
+  type_text: *id003
+  virtualService:
+    description: '[Text representation of VirtualServiceDetail] Connection details
+      of a virtual service (e.g. shared conference call facility with dedicated number/details).'
+    element_property: true
+    items:
+      type: string
+    title: Connection details of a virtual service (e.g. conference call)
+    type: array
+title: Location
+type: object

--- a/tests/integration/data/schemas/medication.yaml
+++ b/tests/integration/data/schemas/medication.yaml
@@ -1,0 +1,227 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: Definition of a Medication. This resource is primarily used for the identification
+  and definition of a medication, including ingredients, for the purposes of prescribing,
+  dispensing, and administering a medication as well as for making statements about
+  medication use. [See https://hl7.org/fhir/R5/Medication.html]
+id: medication
+links:
+- backref: medication
+  label: Medication_marketingAuthorizationHolder_Organization_medication
+  multiplicity: many_to_many
+  name: marketingAuthorizationHolder
+  required: false
+  target_type: organization
+program: '*'
+project: '*'
+properties:
+  batch:
+    description: '[Text representation of MedicationBatch] Information that only applies
+      to packages (not products).'
+    element_property: true
+    title: Details about packaged medications
+    type: string
+  code:
+    binding_description: A coded concept that defines the type of a medication.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-codes
+    binding_version: null
+    description: 'text representation. A code (or set of codes) that specify this
+      medication, or a textual description if no code is available. Usage note: This
+      could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP
+      etc. It could also be a national or local formulary code, optionally with translations
+      to other code systems.'
+    element_property: true
+    term:
+      description: A coded concept that defines the type of a medication.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/medication-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/medication-codes
+        term_url: http://hl7.org/fhir/ValueSet/medication-codes
+    title: Codes that identify this medication
+    type: string
+  code_coding: &id001
+    binding_description: A coded concept that defines the type of a medication.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-codes
+    binding_version: null
+    description: '[system#code representation.] A code (or set of codes) that specify
+      this medication, or a textual description if no code is available. Usage note:
+      This could be a standard medication code such as a code from RxNorm, SNOMED
+      CT, IDMP etc. It could also be a national or local formulary code, optionally
+      with translations to other code systems.'
+    element_property: true
+    term:
+      description: A coded concept that defines the type of a medication.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/medication-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/medication-codes
+        term_url: http://hl7.org/fhir/ValueSet/medication-codes
+    title: Codes that identify this medication
+    type: string
+  code_text: *id001
+  definition:
+    backref: medication
+    description: '[Text representation of Reference] A reference to a knowledge resource
+      that provides more information about this medication.'
+    element_property: true
+    enum_reference_types:
+    - MedicationKnowledge
+    title: Knowledge about this medication
+    type: string
+  doseForm:
+    binding_description: A coded concept defining the form of a medication.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-form-codes
+    binding_version: null
+    description: text representation. Describes the form of the item.  Powder; tablets;
+      capsule.
+    element_property: true
+    term:
+      description: A coded concept defining the form of a medication.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/medication-form-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/medication-form-codes
+        term_url: http://hl7.org/fhir/ValueSet/medication-form-codes
+    title: powder | tablets | capsule +
+    type: string
+  doseForm_coding: &id002
+    binding_description: A coded concept defining the form of a medication.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-form-codes
+    binding_version: null
+    description: '[system#code representation.] Describes the form of the item.  Powder;
+      tablets; capsule.'
+    element_property: true
+    term:
+      description: A coded concept defining the form of a medication.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/medication-form-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/medication-form-codes
+        term_url: http://hl7.org/fhir/ValueSet/medication-form-codes
+    title: powder | tablets | capsule +
+    type: string
+  doseForm_text: *id002
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Business identifier for this medication
+    element_property: true
+    items:
+      type: string
+    title: Business identifier for this medication
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Business identifier for
+      this medication'
+    element_property: true
+    items:
+      type: string
+    title: Business identifier for this medication
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Business identifier
+      for this medication'
+    element_property: true
+    items:
+      type: string
+    title: Business identifier for this medication
+    type: array
+  ingredient:
+    description: '[Text representation of MedicationIngredient] Identifies a particular
+      constituent of interest in the product.'
+    element_property: true
+    items:
+      type: string
+    title: Active or inactive ingredient
+    type: array
+  marketingAuthorizationHolder:
+    backref: medication
+    description: '[Text representation of Reference] The company or other legal entity
+      that has authorization, from the appropriate drug regulatory authority,  to
+      market a medicine in one or more jurisdictions.  Typically abbreviated MAH.Note:  The
+      MAH may manufacture the product and may also contract the manufacturing of the
+      product to one or more companies (organizations).'
+    element_property: true
+    enum_reference_types:
+    - Organization
+    title: Organization that has authorization to market medication
+    type: string
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  resourceType:
+    const: Medication
+    default: Medication
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  status:
+    binding_description: A coded concept defining if the medication is in active use.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-status
+    binding_version: 5.0.0
+    description: A code to indicate if the medication is in active use.
+    element_property: true
+    enum_values:
+    - active
+    - inactive
+    - entered-in-error
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: active | inactive | entered-in-error
+    type: string
+  totalVolume:
+    description: '[Text representation of Quantity] text representation. When the
+      specified product code does not infer a package size, this is the specific amount
+      of drug in the product.  For example, when specifying a product that has the
+      same strength (For example, Insulin glargine 100 unit per mL solution for injection),
+      this attribute provides additional clarification of the package amount (For
+      example, 3 mL, 10mL, etc.).'
+    element_property: true
+    title: When the specified product code does not infer a package size, this is
+      the specific amount of drug in the product
+    type: string
+  totalVolume_unit:
+    title: Unit representation. When the specified product code does not infer a package
+      size, this is the specific amount of drug in the product
+    type: string
+  totalVolume_value:
+    title: Numerical value (with implicit precision) representation. When the specified
+      product code does not infer a package size, this is the specific amount of drug
+      in the product
+    type: number
+title: Medication
+type: object

--- a/tests/integration/data/schemas/medication_administration.yaml
+++ b/tests/integration/data/schemas/medication_administration.yaml
@@ -1,0 +1,573 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: Administration of medication to a patient. Describes the event of a patient
+  consuming or otherwise being administered a medication.  This may be as simple as
+  swallowing a tablet or it may be a long running infusion.  Related resources tie
+  this event to the authorizing prescription, and the specific encounter between patient
+  and health care practitioner. [See https://hl7.org/fhir/R5/MedicationAdministration.html]
+id: medication_administration
+links:
+- backref: medication_administration
+  label: MedicationAdministration_subject_Patient_medication_administration
+  multiplicity: many_to_many
+  name: subject_Patient
+  required: false
+  target_type: patient
+- backref: medication_administration
+  label: MedicationAdministration_encounter_Encounter_medication_administration
+  multiplicity: many_to_many
+  name: encounter
+  required: false
+  target_type: encounter
+- backref: medication_administration
+  label: MedicationAdministration_medication_Medication_medication_administration
+  multiplicity: many_to_many
+  name: medication
+  required: false
+  target_type: medication
+- backref: partOf_medication_administration
+  label: MedicationAdministration_partOf_MedicationAdministration_partOf_medication_administration
+  multiplicity: many_to_many
+  name: partOf_MedicationAdministration
+  required: false
+  target_type: medication_administration
+- backref: partOf_medication_administration
+  label: MedicationAdministration_partOf_Procedure_partOf_medication_administration
+  multiplicity: many_to_many
+  name: partOf_Procedure
+  required: false
+  target_type: procedure
+- backref: reason_medication_administration
+  label: MedicationAdministration_reason_Condition_reason_medication_administration
+  multiplicity: many_to_many
+  name: reason_Condition
+  required: false
+  target_type: condition
+- backref: reason_medication_administration
+  label: MedicationAdministration_reason_Observation_reason_medication_administration
+  multiplicity: many_to_many
+  name: reason_Observation
+  required: false
+  target_type: observation
+- backref: reason_medication_administration
+  label: MedicationAdministration_reason_DiagnosticReport_reason_medication_administration
+  multiplicity: many_to_many
+  name: reason_DiagnosticReport
+  required: false
+  target_type: diagnostic_report
+program: '*'
+project: '*'
+properties:
+  basedOn:
+    backref: basedOn_medication_administration
+    description: '[Text representation of Reference] A plan that is fulfilled in whole
+      or in part by this MedicationAdministration.'
+    element_property: true
+    enum_reference_types:
+    - CarePlan
+    items:
+      type: string
+    title: Plan this is fulfilled by this administration
+    type: array
+  category:
+    binding_description: A coded concept describing where the medication administered
+      is expected to occur.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-admin-location
+    binding_version: null
+    description: text representation. The type of medication administration (for example,
+      drug classification like ATC, where meds would be administered, legal category
+      of the medication).
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A coded concept describing where the medication administered is
+        expected to occur.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/medication-admin-location
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/medication-admin-location
+        term_url: http://hl7.org/fhir/ValueSet/medication-admin-location
+    title: Type of medication administration
+    type: array
+  category_coding: &id001
+    binding_description: A coded concept describing where the medication administered
+      is expected to occur.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-admin-location
+    binding_version: null
+    description: '[system#code representation.] The type of medication administration
+      (for example, drug classification like ATC, where meds would be administered,
+      legal category of the medication).'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A coded concept describing where the medication administered is
+        expected to occur.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/medication-admin-location
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/medication-admin-location
+        term_url: http://hl7.org/fhir/ValueSet/medication-admin-location
+    title: Type of medication administration
+    type: array
+  category_text: *id001
+  device:
+    backref: device_medication_administration
+    description: text representation. The device that is to be used for the administration
+      of the medication (for example, PCA Pump).
+    element_property: true
+    enum_reference_types:
+    - Device
+    items:
+      type: string
+    title: Device used to administer
+    type: array
+  device_coding: &id002
+    backref: device_medication_administration
+    description: '[system#code representation.] The device that is to be used for
+      the administration of the medication (for example, PCA Pump).'
+    element_property: true
+    enum_reference_types:
+    - Device
+    items:
+      type: string
+    title: Device used to administer
+    type: array
+  device_text: *id002
+  dosage:
+    description: '[Text representation of MedicationAdministrationDosage] Describes
+      the medication dosage information details e.g. dose, rate, site, route, etc.'
+    element_property: true
+    title: Details of how medication was taken
+    type: string
+  encounter:
+    backref: medication_administration
+    description: '[Text representation of Reference] The visit, admission, or other
+      contact between patient and health care provider during which the medication
+      administration was performed.'
+    element_property: true
+    enum_reference_types:
+    - Encounter
+    title: Encounter administered as part of
+    type: string
+  eventHistory:
+    backref: eventHistory_medication_administration
+    description: '[Text representation of Reference] A summary of the events of interest
+      that have occurred, such as when the administration was verified.'
+    element_property: true
+    enum_reference_types:
+    - Provenance
+    items:
+      type: string
+    title: A list of events of interest in the lifecycle
+    type: array
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Identifiers associated with this Medication Administration that are
+      defined by business processes and/or used to refer to it when a direct URL reference
+      to the resource itself is not appropriate. They are business identifiers assigned
+      to this resource by the performer or other systems and remain constant as the
+      resource is updated and propagates from server to server.
+    element_property: true
+    items:
+      type: string
+    title: External identifier
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Identifiers associated
+      with this Medication Administration that are defined by business processes and/or
+      used to refer to it when a direct URL reference to the resource itself is not
+      appropriate. They are business identifiers assigned to this resource by the
+      performer or other systems and remain constant as the resource is updated and
+      propagates from server to server.'
+    element_property: true
+    items:
+      type: string
+    title: External identifier
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Identifiers associated
+      with this Medication Administration that are defined by business processes and/or
+      used to refer to it when a direct URL reference to the resource itself is not
+      appropriate. They are business identifiers assigned to this resource by the
+      performer or other systems and remain constant as the resource is updated and
+      propagates from server to server.'
+    element_property: true
+    items:
+      type: string
+    title: External identifier
+    type: array
+  isSubPotent:
+    description: An indication that the full dose was not administered.
+    element_property: true
+    title: Full dose was not administered
+    type: boolean
+  medication:
+    backref: medication_administration
+    binding_description: Codes identifying substance or product that can be administered.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-codes
+    binding_version: null
+    description: text representation. Identifies the medication that was administered.
+      This is either a link to a resource representing the details of the medication
+      or a simple attribute carrying a code that identifies the medication from a
+      known list of medications.
+    element_property: true
+    enum_reference_types:
+    - Medication
+    term:
+      description: Codes identifying substance or product that can be administered.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/medication-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/medication-codes
+        term_url: http://hl7.org/fhir/ValueSet/medication-codes
+    title: What was administered
+    type: string
+  medication_coding: &id003
+    backref: medication_administration
+    binding_description: Codes identifying substance or product that can be administered.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-codes
+    binding_version: null
+    description: '[system#code representation.] Identifies the medication that was
+      administered. This is either a link to a resource representing the details of
+      the medication or a simple attribute carrying a code that identifies the medication
+      from a known list of medications.'
+    element_property: true
+    enum_reference_types:
+    - Medication
+    term:
+      description: Codes identifying substance or product that can be administered.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/medication-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/medication-codes
+        term_url: http://hl7.org/fhir/ValueSet/medication-codes
+    title: What was administered
+    type: string
+  medication_text: *id003
+  note:
+    description: '[Text representation of Annotation] Extra information about the
+      medication administration that is not conveyed by the other attributes.'
+    element_property: true
+    items:
+      type: string
+    title: Information about the administration
+    type: array
+  occurenceDateTime:
+    description: A specific date/time or interval of time during which the administration
+      took place (or did not take place). For many administrations, such as swallowing
+      a tablet the use of dateTime is more appropriate.
+    element_property: true
+    format: date-time
+    one_of_many: occurence
+    one_of_many_required: true
+    title: Specific date/time or interval of time during which the administration
+      took place (or did not take place)
+    type: string
+  occurencePeriod:
+    description: '[Text representation of Period] A specific date/time or interval
+      of time during which the administration took place (or did not take place).
+      For many administrations, such as swallowing a tablet the use of dateTime is
+      more appropriate.'
+    element_property: true
+    one_of_many: occurence
+    one_of_many_required: true
+    title: Specific date/time or interval of time during which the administration
+      took place (or did not take place)
+    type: string
+  occurenceTiming:
+    description: '[Text representation of Timing] A specific date/time or interval
+      of time during which the administration took place (or did not take place).
+      For many administrations, such as swallowing a tablet the use of dateTime is
+      more appropriate.'
+    element_property: true
+    one_of_many: occurence
+    one_of_many_required: true
+    title: Specific date/time or interval of time during which the administration
+      took place (or did not take place)
+    type: string
+  partOf:
+    backref: partOf_medication_administration
+    description: '[Text representation of Reference] A larger event of which this
+      particular event is a component or step.'
+    element_property: true
+    enum_reference_types:
+    - MedicationAdministration
+    - Procedure
+    - MedicationDispense
+    items:
+      type: string
+    title: Part of referenced event
+    type: array
+  performer:
+    description: '[Text representation of MedicationAdministrationPerformer] The performer
+      of the medication treatment.  For devices this is the device that performed
+      the administration of the medication.  An IV Pump would be an example of a device
+      that is performing the administration. Both the IV Pump and the practitioner
+      that set the rate or bolus on the pump can be listed as performers.'
+    element_property: true
+    items:
+      type: string
+    title: Who or what performed the medication administration and what type of performance
+      they did
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  reason:
+    backref: reason_medication_administration
+    binding_description: A set of codes indicating the reason why the MedicationAdministration
+      was made.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/reason-medication-given-codes
+    binding_version: null
+    description: text representation. A code, Condition or observation that supports
+      why the medication was administered.
+    element_property: true
+    enum_reference_types:
+    - Condition
+    - Observation
+    - DiagnosticReport
+    items:
+      type: string
+    term:
+      description: A set of codes indicating the reason why the MedicationAdministration
+        was made.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/reason-medication-given-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/reason-medication-given-codes
+        term_url: http://hl7.org/fhir/ValueSet/reason-medication-given-codes
+    title: Concept, condition or observation that supports why the medication was
+      administered
+    type: array
+  reason_coding: &id004
+    backref: reason_medication_administration
+    binding_description: A set of codes indicating the reason why the MedicationAdministration
+      was made.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/reason-medication-given-codes
+    binding_version: null
+    description: '[system#code representation.] A code, Condition or observation that
+      supports why the medication was administered.'
+    element_property: true
+    enum_reference_types:
+    - Condition
+    - Observation
+    - DiagnosticReport
+    items:
+      type: string
+    term:
+      description: A set of codes indicating the reason why the MedicationAdministration
+        was made.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/reason-medication-given-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/reason-medication-given-codes
+        term_url: http://hl7.org/fhir/ValueSet/reason-medication-given-codes
+    title: Concept, condition or observation that supports why the medication was
+      administered
+    type: array
+  reason_text: *id004
+  recorded:
+    description: The date the occurrence of the  MedicationAdministration was first
+      captured in the record - potentially significantly after the occurrence of the
+      event.
+    element_property: true
+    format: date-time
+    title: When the MedicationAdministration was first captured in the subject's record
+    type: string
+  request:
+    backref: medication_administration
+    description: '[Text representation of Reference] The original request, instruction
+      or authority to perform the administration.'
+    element_property: true
+    enum_reference_types:
+    - MedicationRequest
+    title: Request administration performed against
+    type: string
+  resourceType:
+    const: MedicationAdministration
+    default: MedicationAdministration
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  status:
+    binding_description: A set of codes indicating the current status of a MedicationAdministration.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/medication-admin-status
+    binding_version: 5.0.0
+    description: Will generally be set to show that the administration has been completed.  For
+      some long running administrations such as infusions, it is possible for an administration
+      to be started but not completed or it may be paused while some other process
+      is under way.
+    element_property: true
+    element_required: true
+    enum_values:
+    - in-progress
+    - not-done
+    - on-hold
+    - completed
+    - entered-in-error
+    - stopped
+    - unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: in-progress | not-done | on-hold | completed | entered-in-error | stopped
+      | unknown
+    type: string
+  statusReason:
+    binding_description: A set of codes indicating the reason why the MedicationAdministration
+      is negated.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes
+    binding_version: null
+    description: text representation. A code indicating why the administration was
+      not performed.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A set of codes indicating the reason why the MedicationAdministration
+        is negated.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes
+        term_url: http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes
+    title: Reason administration not performed
+    type: array
+  statusReason_coding: &id005
+    binding_description: A set of codes indicating the reason why the MedicationAdministration
+      is negated.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes
+    binding_version: null
+    description: '[system#code representation.] A code indicating why the administration
+      was not performed.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A set of codes indicating the reason why the MedicationAdministration
+        is negated.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes
+        term_url: http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes
+    title: Reason administration not performed
+    type: array
+  statusReason_text: *id005
+  subPotentReason:
+    binding_description: null
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/administration-subpotent-reason
+    binding_version: null
+    description: text representation. The reason or reasons why the full dose was
+      not administered.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: null
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/administration-subpotent-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/administration-subpotent-reason
+        term_url: http://hl7.org/fhir/ValueSet/administration-subpotent-reason
+    title: Reason full dose was not administered
+    type: array
+  subPotentReason_coding: &id006
+    binding_description: null
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/administration-subpotent-reason
+    binding_version: null
+    description: '[system#code representation.] The reason or reasons why the full
+      dose was not administered.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: null
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/administration-subpotent-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/administration-subpotent-reason
+        term_url: http://hl7.org/fhir/ValueSet/administration-subpotent-reason
+    title: Reason full dose was not administered
+    type: array
+  subPotentReason_text: *id006
+  subject:
+    backref: medication_administration
+    description: '[Text representation of Reference] The person or animal or group
+      receiving the medication.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Group
+    title: Who received medication
+    type: string
+  supportingInformation:
+    backref: supportingInformation_medication_administration
+    description: '[Text representation of Reference] Additional information (for example,
+      patient height and weight) that supports the administration of the medication.  This
+      attribute can be used to provide documentation of specific characteristics of
+      the patient present at the time of administration.  For example, if the dose
+      says "give "x" if the heartrate exceeds "y"", then the heart rate can be included
+      using this attribute.'
+    element_property: true
+    enum_reference_types:
+    - Resource
+    items:
+      type: string
+    title: Additional information to support administration
+    type: array
+title: MedicationAdministration
+type: object

--- a/tests/integration/data/schemas/observation.yaml
+++ b/tests/integration/data/schemas/observation.yaml
@@ -1,0 +1,742 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: Measurements and simple assertions. Measurements and simple assertions
+  made about a patient, device or other subject. [See https://hl7.org/fhir/R5/Observation.html]
+id: observation
+links:
+- backref: subject_observation
+  label: Observation_subject_Patient_subject_observation
+  multiplicity: many_to_many
+  name: subject_Patient
+  required: false
+  target_type: patient
+- backref: focus_observation
+  label: Observation_focus_ResearchStudy_focus_observation
+  multiplicity: many_to_many
+  name: focus
+  required: false
+  target_type: research_study
+- backref: specimen_observation
+  label: Observation_specimen_Specimen_specimen_observation
+  multiplicity: many_to_many
+  name: specimen_Specimen
+  required: false
+  target_type: specimen
+program: '*'
+project: '*'
+properties:
+  basedOn:
+    backref: basedOn_observation
+    description: '[Text representation of Reference] A plan, proposal or order that
+      is fulfilled in whole or in part by this event.  For example, a MedicationRequest
+      may require a patient to have laboratory test performed before  it is dispensed.'
+    element_property: true
+    enum_reference_types:
+    - CarePlan
+    - DeviceRequest
+    - ImmunizationRecommendation
+    - MedicationRequest
+    - NutritionOrder
+    - ServiceRequest
+    items:
+      type: string
+    title: Fulfills plan, proposal or order
+    type: array
+  bodySite:
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: text representation. Indicates the site on the subject's body where
+      the observation was made (i.e. the target site).
+    element_property: true
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Observed body part
+    type: string
+  bodySite_coding: &id001
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: '[system#code representation.] Indicates the site on the subject''s
+      body where the observation was made (i.e. the target site).'
+    element_property: true
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Observed body part
+    type: string
+  bodySite_text: *id001
+  bodyStructure:
+    backref: observation
+    description: '[Text representation of Reference] Indicates the body structure
+      on the subject''s body where the observation was made (i.e. the target site).'
+    element_property: true
+    enum_reference_types:
+    - BodyStructure
+    title: Observed body structure
+    type: string
+  category:
+    binding_description: Codes for high level observation categories.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/observation-category
+    binding_version: null
+    description: text representation. A code that classifies the general type of observation
+      being made.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Codes for high level observation categories.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/observation-category
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/observation-category
+        term_url: http://hl7.org/fhir/ValueSet/observation-category
+    title: Classification of  type of observation
+    type: array
+  category_coding: &id002
+    binding_description: Codes for high level observation categories.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/observation-category
+    binding_version: null
+    description: '[system#code representation.] A code that classifies the general
+      type of observation being made.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Codes for high level observation categories.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/observation-category
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/observation-category
+        term_url: http://hl7.org/fhir/ValueSet/observation-category
+    title: Classification of  type of observation
+    type: array
+  category_text: *id002
+  code:
+    binding_description: LDL Cholesterol codes - measured or calculated.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/lipid-ldl-codes
+    binding_version: null
+    description: text representation. Describes what was observed. Sometimes this
+      is called the observation "name".
+    element_property: true
+    term:
+      description: LDL Cholesterol codes - measured or calculated.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/lipid-ldl-codes
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/ValueSet/lipid-ldl-codes
+        term_url: http://hl7.org/fhir/ValueSet/lipid-ldl-codes
+    title: Type of observation (code / type)
+    type: string
+  code_coding: &id003
+    binding_description: LDL Cholesterol codes - measured or calculated.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/lipid-ldl-codes
+    binding_version: null
+    description: '[system#code representation.] Describes what was observed. Sometimes
+      this is called the observation "name".'
+    element_property: true
+    term:
+      description: LDL Cholesterol codes - measured or calculated.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/lipid-ldl-codes
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/ValueSet/lipid-ldl-codes
+        term_url: http://hl7.org/fhir/ValueSet/lipid-ldl-codes
+    title: Type of observation (code / type)
+    type: string
+  code_text: *id003
+  component:
+    description: '[Text representation of ObservationComponent] Some observations
+      have multiple component observations.  These component observations are expressed
+      as separate code value pairs that share the same attributes.  Examples include
+      systolic and diastolic component observations for blood pressure measurement
+      and multiple component observations for genetics observations.'
+    element_property: true
+    items:
+      type: string
+    title: Component results
+    type: array
+  dataAbsentReason:
+    binding_description: Codes specifying why the result (`Observation.value[x]`)
+      is missing.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/data-absent-reason
+    binding_version: null
+    description: text representation. Provides a reason why the expected value in
+      the element Observation.value[x] is missing.
+    element_property: true
+    term:
+      description: Codes specifying why the result (`Observation.value[x]`) is missing.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/data-absent-reason
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/data-absent-reason
+        term_url: http://hl7.org/fhir/ValueSet/data-absent-reason
+    title: Why the result is missing
+    type: string
+  dataAbsentReason_coding: &id004
+    binding_description: Codes specifying why the result (`Observation.value[x]`)
+      is missing.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/data-absent-reason
+    binding_version: null
+    description: '[system#code representation.] Provides a reason why the expected
+      value in the element Observation.value[x] is missing.'
+    element_property: true
+    term:
+      description: Codes specifying why the result (`Observation.value[x]`) is missing.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/data-absent-reason
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/data-absent-reason
+        term_url: http://hl7.org/fhir/ValueSet/data-absent-reason
+    title: Why the result is missing
+    type: string
+  dataAbsentReason_text: *id004
+  derivedFrom:
+    backref: derivedFrom_observation
+    description: '[Text representation of Reference] The target resource that represents
+      a measurement from which this observation value is derived. For example, a calculated
+      anion gap or a fetal measurement based on an ultrasound image.'
+    element_property: true
+    enum_reference_types:
+    - DocumentReference
+    - ImagingStudy
+    - ImagingSelection
+    - QuestionnaireResponse
+    - Observation
+    - MolecularSequence
+    - GenomicStudy
+    items:
+      type: string
+    title: Related resource from which the observation is made
+    type: array
+  device:
+    backref: device_observation
+    description: '[Text representation of Reference] A reference to the device that
+      generates the measurements or the device settings for the device'
+    element_property: true
+    enum_reference_types:
+    - Device
+    - DeviceMetric
+    title: A reference to the device that generates the measurements or the device
+      settings for the device
+    type: string
+  effectiveDateTime:
+    description: The time or time-period the observed value is asserted as being true.
+      For biological subjects - e.g. human patients - this is usually called the "physiologically
+      relevant time". This is usually either the time of the procedure or of specimen
+      collection, but very often the source of the date/time is not known, only the
+      date/time itself.
+    element_property: true
+    format: date-time
+    one_of_many: effective
+    one_of_many_required: false
+    title: Clinically relevant time/time-period for observation
+    type: string
+  effectiveInstant:
+    description: The time or time-period the observed value is asserted as being true.
+      For biological subjects - e.g. human patients - this is usually called the "physiologically
+      relevant time". This is usually either the time of the procedure or of specimen
+      collection, but very often the source of the date/time is not known, only the
+      date/time itself.
+    element_property: true
+    format: date-time
+    one_of_many: effective
+    one_of_many_required: false
+    title: Clinically relevant time/time-period for observation
+    type: string
+  effectivePeriod:
+    description: '[Text representation of Period] The time or time-period the observed
+      value is asserted as being true. For biological subjects - e.g. human patients
+      - this is usually called the "physiologically relevant time". This is usually
+      either the time of the procedure or of specimen collection, but very often the
+      source of the date/time is not known, only the date/time itself.'
+    element_property: true
+    one_of_many: effective
+    one_of_many_required: false
+    title: Clinically relevant time/time-period for observation
+    type: string
+  effectiveTiming:
+    description: '[Text representation of Timing] The time or time-period the observed
+      value is asserted as being true. For biological subjects - e.g. human patients
+      - this is usually called the "physiologically relevant time". This is usually
+      either the time of the procedure or of specimen collection, but very often the
+      source of the date/time is not known, only the date/time itself.'
+    element_property: true
+    one_of_many: effective
+    one_of_many_required: false
+    title: Clinically relevant time/time-period for observation
+    type: string
+  encounter:
+    backref: observation
+    description: '[Text representation of Reference] The healthcare event  (e.g. a
+      patient and healthcare provider interaction) during which this observation is
+      made.'
+    element_property: true
+    enum_reference_types:
+    - Encounter
+    title: Healthcare event during which this observation is made
+    type: string
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  focus:
+    backref: focus_observation
+    description: '[Text representation of Reference] The actual focus of an observation
+      when it is not the patient of record representing something or someone associated
+      with the patient such as a spouse, parent, fetus, or donor.'
+    element_property: true
+    enum_reference_types:
+    - ResearchStudy
+    items:
+      type: string
+    title: What the observation is about, when it is not about the subject of record
+    type: array
+  hasMember:
+    backref: hasMember_observation
+    description: '[Text representation of Reference] This observation is a group observation
+      (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes
+      the target as a member of the group.'
+    element_property: true
+    enum_reference_types:
+    - Observation
+    - QuestionnaireResponse
+    - MolecularSequence
+    items:
+      type: string
+    title: Related resource that belongs to the Observation group
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: A unique identifier assigned to this observation.
+    element_property: true
+    items:
+      type: string
+    title: Business Identifier for observation
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] A unique identifier assigned
+      to this observation.'
+    element_property: true
+    items:
+      type: string
+    title: Business Identifier for observation
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] A unique identifier
+      assigned to this observation.'
+    element_property: true
+    items:
+      type: string
+    title: Business Identifier for observation
+    type: array
+  instantiatesCanonical:
+    description: The reference to a FHIR ObservationDefinition resource that provides
+      the definition that is adhered to in whole or in part by this Observation instance.
+    element_property: true
+    enum_reference_types:
+    - ObservationDefinition
+    one_of_many: instantiates
+    one_of_many_required: false
+    pattern: \S*
+    title: Instantiates FHIR ObservationDefinition
+    type: string
+  instantiatesReference:
+    backref: observation
+    description: '[Text representation of Reference] The reference to a FHIR ObservationDefinition
+      resource that provides the definition that is adhered to in whole or in part
+      by this Observation instance.'
+    element_property: true
+    enum_reference_types:
+    - ObservationDefinition
+    one_of_many: instantiates
+    one_of_many_required: false
+    title: Instantiates FHIR ObservationDefinition
+    type: string
+  interpretation:
+    binding_description: Codes identifying interpretations of observations.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/observation-interpretation
+    binding_version: null
+    description: text representation. A categorical assessment of an observation value.  For
+      example, high, low, normal.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Codes identifying interpretations of observations.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/observation-interpretation
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/observation-interpretation
+        term_url: http://hl7.org/fhir/ValueSet/observation-interpretation
+    title: High, low, normal, etc
+    type: array
+  interpretation_coding: &id005
+    binding_description: Codes identifying interpretations of observations.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/observation-interpretation
+    binding_version: null
+    description: '[system#code representation.] A categorical assessment of an observation
+      value.  For example, high, low, normal.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Codes identifying interpretations of observations.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/observation-interpretation
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/observation-interpretation
+        term_url: http://hl7.org/fhir/ValueSet/observation-interpretation
+    title: High, low, normal, etc
+    type: array
+  interpretation_text: *id005
+  issued:
+    description: The date and time this version of the observation was made available
+      to providers, typically after the results have been reviewed and verified.
+    element_property: true
+    format: date-time
+    title: Date/Time this version was made available
+    type: string
+  method:
+    binding_description: Methods for simple observations.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/observation-methods
+    binding_version: null
+    description: text representation. Indicates the mechanism used to perform the
+      observation.
+    element_property: true
+    term:
+      description: Methods for simple observations.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/observation-methods
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/observation-methods
+        term_url: http://hl7.org/fhir/ValueSet/observation-methods
+    title: How it was done
+    type: string
+  method_coding: &id006
+    binding_description: Methods for simple observations.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/observation-methods
+    binding_version: null
+    description: '[system#code representation.] Indicates the mechanism used to perform
+      the observation.'
+    element_property: true
+    term:
+      description: Methods for simple observations.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/observation-methods
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/observation-methods
+        term_url: http://hl7.org/fhir/ValueSet/observation-methods
+    title: How it was done
+    type: string
+  method_text: *id006
+  note:
+    description: '[Text representation of Annotation] Comments about the observation
+      or the results.'
+    element_property: true
+    items:
+      type: string
+    title: Comments about the observation
+    type: array
+  partOf:
+    backref: partOf_observation
+    description: '[Text representation of Reference] A larger event of which this
+      particular Observation is a component or step.  For example,  an observation
+      as part of a procedure.'
+    element_property: true
+    enum_reference_types:
+    - MedicationAdministration
+    - MedicationDispense
+    - MedicationStatement
+    - Procedure
+    - Immunization
+    - ImagingStudy
+    - GenomicStudy
+    items:
+      type: string
+    title: Part of referenced event
+    type: array
+  performer:
+    backref: performer_observation
+    description: '[Text representation of Reference] Who was responsible for asserting
+      the observed value as "true".'
+    element_property: true
+    enum_reference_types:
+    - Practitioner
+    - PractitionerRole
+    - Organization
+    - CareTeam
+    - Patient
+    - RelatedPerson
+    items:
+      type: string
+    title: Who is responsible for the observation
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  referenceRange:
+    description: '[Text representation of ObservationReferenceRange] Guidance on how
+      to interpret the value by comparison to a normal or recommended range.  Multiple
+      reference ranges are interpreted as an "OR".   In other words, to represent
+      two distinct target populations, two `referenceRange` elements would be used.'
+    element_property: true
+    items:
+      type: string
+    title: Provides guide for interpretation
+    type: array
+  resourceType:
+    const: Observation
+    default: Observation
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  specimen:
+    backref: specimen_observation
+    description: '[Text representation of Reference] The specimen that was used when
+      this observation was made.'
+    element_property: true
+    enum_reference_types:
+    - Specimen
+    - Group
+    title: Specimen used for this observation
+    type: string
+  status:
+    binding_description: Codes providing the status of an observation.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/observation-status
+    binding_version: 5.0.0
+    description: The status of the result value.
+    element_property: true
+    element_required: true
+    enum_values:
+    - registered
+    - preliminary
+    - final
+    - amended
+    - +
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: registered | preliminary | final | amended +
+    type: string
+  subject:
+    backref: subject_observation
+    description: '[Text representation of Reference] The patient, or group of patients,
+      location, device, organization, procedure or practitioner this observation is
+      about and into whose or what record the observation is placed. If the actual
+      focus of the observation is different from the subject (or a sample of, part,
+      or region of the subject), the `focus` element or the `code` itself specifies
+      the actual focus of the observation.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Group
+    - Device
+    - Location
+    - Organization
+    - Procedure
+    - Practitioner
+    - Medication
+    - Substance
+    - BiologicallyDerivedProduct
+    - NutritionProduct
+    title: Who and/or what the observation is about
+    type: string
+  triggeredBy:
+    description: '[Text representation of ObservationTriggeredBy] Identifies the observation(s)
+      that triggered the performance of this observation.'
+    element_property: true
+    items:
+      type: string
+    title: Triggering observation(s)
+    type: array
+  valueAttachment:
+    description: '[Text representation of Attachment] The information determined as
+      a result of making the observation, if the information has a simple value.'
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueBoolean:
+    description: The information determined as a result of making the observation,
+      if the information has a simple value.
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: boolean
+  valueCodeableConcept:
+    description: text representation. The information determined as a result of making
+      the observation, if the information has a simple value.
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueCodeableConcept_coding: &id007
+    description: '[system#code representation.] The information determined as a result
+      of making the observation, if the information has a simple value.'
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueCodeableConcept_text: *id007
+  valueDateTime:
+    description: The information determined as a result of making the observation,
+      if the information has a simple value.
+    element_property: true
+    format: date-time
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueInteger:
+    description: The information determined as a result of making the observation,
+      if the information has a simple value.
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: integer
+  valuePeriod:
+    description: '[Text representation of Period] The information determined as a
+      result of making the observation, if the information has a simple value.'
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueQuantity:
+    description: '[Text representation of Quantity] text representation. The information
+      determined as a result of making the observation, if the information has a simple
+      value.'
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueQuantity_unit:
+    title: Unit representation. Actual result
+    type: string
+  valueQuantity_value:
+    title: Numerical value (with implicit precision) representation. Actual result
+    type: number
+  valueRange:
+    description: '[Text representation of Range] The information determined as a result
+      of making the observation, if the information has a simple value.'
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueRatio:
+    description: '[Text representation of Ratio] The information determined as a result
+      of making the observation, if the information has a simple value.'
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueReference:
+    backref: valueReference_observation
+    description: '[Text representation of Reference] The information determined as
+      a result of making the observation, if the information has a simple value.'
+    element_property: true
+    enum_reference_types:
+    - MolecularSequence
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueSampledData:
+    description: '[Text representation of SampledData] The information determined
+      as a result of making the observation, if the information has a simple value.'
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+  valueString:
+    description: The information determined as a result of making the observation,
+      if the information has a simple value.
+    element_property: true
+    one_of_many: value
+    one_of_many_required: false
+    pattern: '[ \r\n\t\S]+'
+    title: Actual result
+    type: string
+  valueTime:
+    description: The information determined as a result of making the observation,
+      if the information has a simple value.
+    element_property: true
+    format: time
+    one_of_many: value
+    one_of_many_required: false
+    title: Actual result
+    type: string
+title: Observation
+type: object

--- a/tests/integration/data/schemas/organization.yaml
+++ b/tests/integration/data/schemas/organization.yaml
@@ -1,0 +1,190 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Administrative
+description: A grouping of people or organizations with a common purpose. A formally
+  or informally recognized grouping of people or organizations formed for the purpose
+  of achieving some form of collective action. Includes companies, institutions, corporations,
+  departments, community groups, healthcare practice groups, payer/insurer, etc. [See
+  https://hl7.org/fhir/R5/Organization.html]
+id: organization
+links:
+- backref: organization
+  label: Organization_partOf_Organization_organization
+  multiplicity: many_to_many
+  name: partOf
+  required: false
+  target_type: organization
+program: '*'
+project: '*'
+properties:
+  active:
+    description: Whether the organization's record is still in active use
+    element_property: true
+    title: Whether the organization's record is still in active use
+    type: boolean
+  alias:
+    description: A list of alternate names that the organization is known as, or was
+      known as in the past
+    element_property: true
+    items:
+      pattern: '[ \r\n\t\S]+'
+      type: string
+    title: A list of alternate names that the organization is known as, or was known
+      as in the past
+    type: array
+  contact:
+    description: '[Text representation of ExtendedContactDetail] The contact details
+      of communication devices available relevant to the specific Organization. This
+      can include addresses, phone numbers, fax numbers, mobile numbers, email addresses
+      and web sites.'
+    element_property: true
+    items:
+      type: string
+    title: Official contact details for the Organization
+    type: array
+  description:
+    description: Description of the organization, which helps provide additional general
+      context on the organization to ensure that the correct organization is selected.
+    element_property: true
+    pattern: \s*(\S|\s)*
+    title: Additional details about the Organization that could be displayed as further
+      information to identify the Organization beyond its name
+    type: string
+  endpoint:
+    backref: endpoint_organization
+    description: '[Text representation of Reference] Technical endpoints providing
+      access to services operated for the organization'
+    element_property: true
+    enum_reference_types:
+    - Endpoint
+    items:
+      type: string
+    title: Technical endpoints providing access to services operated for the organization
+    type: array
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Identifier for the organization that is used to identify the organization
+      across multiple disparate systems.
+    element_property: true
+    items:
+      type: string
+    title: Identifies this organization  across multiple systems
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Identifier for the organization
+      that is used to identify the organization across multiple disparate systems.'
+    element_property: true
+    items:
+      type: string
+    title: Identifies this organization  across multiple systems
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Identifier for the
+      organization that is used to identify the organization across multiple disparate
+      systems.'
+    element_property: true
+    items:
+      type: string
+    title: Identifies this organization  across multiple systems
+    type: array
+  name:
+    description: A name associated with the organization.
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: Name used for the organization
+    type: string
+  partOf:
+    backref: organization
+    description: '[Text representation of Reference] The organization of which this
+      organization forms a part'
+    element_property: true
+    enum_reference_types:
+    - Organization
+    title: The organization of which this organization forms a part
+    type: string
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  qualification:
+    description: '[Text representation of OrganizationQualification] The official
+      certifications, accreditations, training, designations and licenses that authorize
+      and/or otherwise endorse the provision of care by the organization.  For example,
+      an approval to provide a type of services issued by a certifying body (such
+      as the US Joint Commission) to an organization.'
+    element_property: true
+    items:
+      type: string
+    title: Qualifications, certifications, accreditations, licenses, training, etc.
+      pertaining to the provision of care
+    type: array
+  resourceType:
+    const: Organization
+    default: Organization
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  type:
+    binding_description: Used to categorize the organization.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/organization-type
+    binding_version: null
+    description: text representation. The kind(s) of organization that this is.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Used to categorize the organization.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/organization-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/organization-type
+        term_url: http://hl7.org/fhir/ValueSet/organization-type
+    title: Kind of organization
+    type: array
+  type_coding: &id001
+    binding_description: Used to categorize the organization.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/organization-type
+    binding_version: null
+    description: '[system#code representation.] The kind(s) of organization that this
+      is.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Used to categorize the organization.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/organization-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/organization-type
+        term_url: http://hl7.org/fhir/ValueSet/organization-type
+    title: Kind of organization
+    type: array
+  type_text: *id001
+title: Organization
+type: object

--- a/tests/integration/data/schemas/patient.yaml
+++ b/tests/integration/data/schemas/patient.yaml
@@ -1,0 +1,508 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Administrative
+description: Information about an individual or animal receiving health care services.
+  Demographics and other administrative information about an individual or animal
+  receiving care or other health-related services. [See https://hl7.org/fhir/R5/Patient.html]
+id: patient
+links:
+- backref: generalPractitioner_patient
+  label: Patient_generalPractitioner_Organization_generalPractitioner_patient
+  multiplicity: many_to_many
+  name: generalPractitioner_Organization
+  required: false
+  target_type: organization
+- backref: generalPractitioner_patient
+  label: Patient_generalPractitioner_Practitioner_generalPractitioner_patient
+  multiplicity: many_to_many
+  name: generalPractitioner_Practitioner
+  required: false
+  target_type: practitioner
+- backref: generalPractitioner_patient
+  label: Patient_generalPractitioner_PractitionerRole_generalPractitioner_patient
+  multiplicity: many_to_many
+  name: generalPractitioner_PractitionerRole
+  required: false
+  target_type: practitioner_role
+program: '*'
+project: '*'
+properties:
+  active:
+    description: Whether this patient record is in active use.  Many systems use this
+      property to mark as non-current patients, such as those that have not been seen
+      for a period of time based on an organization's business rules.  It is often
+      used to filter patient lists to exclude inactive patients  Deceased patients
+      may also be marked as inactive for the same reasons, but may be active for some
+      time after death.
+    element_property: true
+    title: Whether this patient's record is in active use
+    type: boolean
+  address_postalCode:
+    description: '[Plucked from Patient.address] A postal code designating a region
+      defined by the postal service.'
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: Postal code for area
+    type: string
+  birthDate:
+    description: The date of birth for the individual
+    element_property: true
+    format: date
+    title: The date of birth for the individual
+    type: string
+  communication:
+    description: '[Text representation of PatientCommunication] A language which may
+      be used to communicate with the patient about his or her health'
+    element_property: true
+    items:
+      type: string
+    title: A language which may be used to communicate with the patient about his
+      or her health
+    type: array
+  contact:
+    description: '[Text representation of PatientContact] A contact party (e.g. guardian,
+      partner, friend) for the patient'
+    element_property: true
+    items:
+      type: string
+    title: A contact party (e.g. guardian, partner, friend) for the patient
+    type: array
+  deceasedBoolean:
+    description: Indicates if the individual is deceased or not
+    element_property: true
+    one_of_many: deceased
+    one_of_many_required: false
+    title: Indicates if the individual is deceased or not
+    type: boolean
+  deceasedDateTime:
+    description: Indicates if the individual is deceased or not
+    element_property: true
+    format: date-time
+    one_of_many: deceased
+    one_of_many_required: false
+    title: Indicates if the individual is deceased or not
+    type: string
+  disability_adjusted_life_years:
+    description: '[extension disability_adjusted_life_years] Disability Adjusted Life
+      Years as defined in the literature and summarized at <a href="https://en.wikipedia.org/wiki/Disability-adjusted_life_year"/>.'
+    type: number
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  gender:
+    binding_description: The gender of a person used for administrative purposes.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/administrative-gender
+    binding_version: 5.0.0
+    description: Administrative Gender - the gender that the patient is considered
+      to have for administration and record keeping purposes.
+    element_property: true
+    enum_values:
+    - male
+    - female
+    - other
+    - unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: male | female | other | unknown
+    type: string
+  generalPractitioner:
+    backref: generalPractitioner_patient
+    description: '[Text representation of Reference] Patient''s nominated care provider.'
+    element_property: true
+    enum_reference_types:
+    - Organization
+    - Practitioner
+    - PractitionerRole
+    items:
+      type: string
+    title: Patient's nominated primary care provider
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: An identifier for this patient
+    element_property: true
+    items:
+      type: string
+    title: An identifier for this patient
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] An identifier for this
+      patient'
+    element_property: true
+    items:
+      type: string
+    title: An identifier for this patient
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] An identifier for
+      this patient'
+    element_property: true
+    items:
+      type: string
+    title: An identifier for this patient
+    type: array
+  link:
+    description: '[Text representation of PatientLink] Link to a Patient or RelatedPerson
+      resource that concerns the same actual individual'
+    element_property: true
+    items:
+      type: string
+    title: Link to a Patient or RelatedPerson resource that concerns the same actual
+      individual
+    type: array
+  managingOrganization:
+    backref: managingOrganization_patient
+    description: '[Text representation of Reference] Organization that is the custodian
+      of the patient record'
+    element_property: true
+    enum_reference_types:
+    - Organization
+    title: Organization that is the custodian of the patient record
+    type: string
+  maritalStatus:
+    binding_description: The domestic partnership status of a person.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/marital-status
+    binding_version: null
+    description: text representation. This field contains a patient's most recent
+      marital (civil) status.
+    element_property: true
+    term:
+      description: The domestic partnership status of a person.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/marital-status
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/marital-status
+        term_url: http://hl7.org/fhir/ValueSet/marital-status
+    title: Marital (civil) status of a patient
+    type: string
+  maritalStatus_coding: &id001
+    binding_description: The domestic partnership status of a person.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/marital-status
+    binding_version: null
+    description: '[system#code representation.] This field contains a patient''s most
+      recent marital (civil) status.'
+    element_property: true
+    term:
+      description: The domestic partnership status of a person.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/marital-status
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/marital-status
+        term_url: http://hl7.org/fhir/ValueSet/marital-status
+    title: Marital (civil) status of a patient
+    type: string
+  maritalStatus_text: *id001
+  multipleBirthBoolean:
+    description: Indicates whether the patient is part of a multiple (boolean) or
+      indicates the actual birth order (integer).
+    element_property: true
+    one_of_many: multipleBirth
+    one_of_many_required: false
+    title: Whether patient is part of a multiple birth
+    type: boolean
+  multipleBirthInteger:
+    description: Indicates whether the patient is part of a multiple (boolean) or
+      indicates the actual birth order (integer).
+    element_property: true
+    one_of_many: multipleBirth
+    one_of_many_required: false
+    title: Whether patient is part of a multiple birth
+    type: integer
+  name:
+    description: '[Text representation of HumanName] A name associated with the individual.'
+    element_property: true
+    items:
+      type: string
+    title: A name associated with the patient
+    type: array
+  patient_birthPlace:
+    description: '[Text representation of Address] [extension patient_birthPlace]
+      The registered place of birth of the patient. A sytem may use the address.text
+      if they don''t store the birthPlace address in discrete elements.'
+    type: string
+  patient_mothersMaidenName:
+    description: '[extension patient_mothersMaidenName] Mother''s maiden (unmarried)
+      name, commonly collected to help verify patient identity.'
+    type: string
+  photo:
+    description: '[Text representation of Attachment] Image of the patient'
+    element_property: true
+    items:
+      type: string
+    title: Image of the patient
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  quality_adjusted_life_years:
+    description: '[extension quality_adjusted_life_years] Quality Adjusted Life Years
+      as defined in the literature and summarized at <a href="https://en.wikipedia.org/wiki/Quality-adjusted_life_year"/>.'
+    type: number
+  resourceType:
+    const: Patient
+    default: Patient
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  telecom:
+    description: '[Text representation of ContactPoint] A contact detail (e.g. a telephone
+      number or an email address) by which the individual may be contacted.'
+    element_property: true
+    items:
+      type: string
+    title: A contact detail for the individual
+    type: array
+  us_core_birthsex:
+    binding_description: Code for sex assigned at birth
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/us/core/ValueSet/birthsex
+    binding_version: null
+    description: '[extension us_core_birthsex] A code classifying the person''s sex
+      assigned at birth  as specified by the [Office of the National Coordinator for
+      Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension
+      aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).'
+    term:
+      description: Code for sex assigned at birth
+      termDef:
+        cde_id: http://hl7.org/fhir/us/core/ValueSet/birthsex
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/us/core/ValueSet/birthsex
+        term_url: http://hl7.org/fhir/us/core/ValueSet/birthsex
+    type: string
+  us_core_ethnicity:
+    description: '[extension us_core_ethnicity] Concepts classifying the person into
+      a named category of humans sharing common history, traits, geographical origin
+      or nationality.  The ethnicity codes used to represent these concepts are based
+      upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html)
+      which includes over 900 concepts for representing race and ethnicity of which
+      43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped
+      to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.'
+    type: string
+  us_core_ethnicity_detailed:
+    binding_description: null
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity
+    binding_version: null
+    description: '[Text representation of Coding] [extension us_core_ethnicity] Concepts
+      classifying the person into a named category of humans sharing common history,
+      traits, geographical origin or nationality.  The ethnicity codes used to represent
+      these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version
+      1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes
+      over 900 concepts for representing race and ethnicity of which 43 reference
+      ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB
+      ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.'
+    term:
+      description: null
+      termDef:
+        cde_id: http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity
+        term_url: http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity
+    type: string
+  us_core_ethnicity_ombCategory:
+    binding_description: null
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category
+    binding_version: null
+    description: '[Text representation of Coding] [extension us_core_ethnicity] Concepts
+      classifying the person into a named category of humans sharing common history,
+      traits, geographical origin or nationality.  The ethnicity codes used to represent
+      these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version
+      1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes
+      over 900 concepts for representing race and ethnicity of which 43 reference
+      ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB
+      ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.'
+    term:
+      description: null
+      termDef:
+        cde_id: http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category
+        term_url: http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category
+    type: string
+  us_core_genderIdentity:
+    binding_description: null
+    binding_strength: extensible
+    binding_uri: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32
+    binding_version: null
+    description: text representation. [extension us_core_genderIdentity] This extension
+      represents an individual's sense of being a man, woman, boy, girl, nonbinary,
+      or something else, ascertained by asking them what that identity is. Systems
+      requiring multiple gender identities and associated dates **SHOULD** use the
+      FHIR R5 [genderIdentity extension](http://hl7.org/fhir/extensions/StructureDefinition-individual-genderIdentity.html).
+      When future versions of US Core are based on FHIR R5, the FHIR R5 extension
+      will supersede this extension.
+    term:
+      description: null
+      termDef:
+        cde_id: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32
+        term_url: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32
+    type: string
+  us_core_genderIdentity_coding: &id002
+    binding_description: null
+    binding_strength: extensible
+    binding_uri: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32
+    binding_version: null
+    description: '[system#code representation.] [extension us_core_genderIdentity]
+      This extension represents an individual''s sense of being a man, woman, boy,
+      girl, nonbinary, or something else, ascertained by asking them what that identity
+      is. Systems requiring multiple gender identities and associated dates **SHOULD**
+      use the FHIR R5 [genderIdentity extension](http://hl7.org/fhir/extensions/StructureDefinition-individual-genderIdentity.html).
+      When future versions of US Core are based on FHIR R5, the FHIR R5 extension
+      will supersede this extension.'
+    term:
+      description: null
+      termDef:
+        cde_id: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32
+        term_url: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32
+    type: string
+  us_core_genderIdentity_text: *id002
+  us_core_race:
+    description: "[extension us_core_race] Concepts classifying the person into a\
+      \ named category of humans sharing common history, traits, geographical origin\
+      \ or nationality.  The race codes used to represent these concepts are based\
+      \ upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html)\
+      \ which includes over 900 concepts for representing race and ethnicity of which\
+      \ 921 reference race.  The race concepts are grouped by and pre-mapped to the\
+      \ 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n\
+      \ - Black or African American\n - Native Hawaiian or Other Pacific Islander\n\
+      \ - White."
+    type: string
+  us_core_race_detailed:
+    binding_description: null
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/us/core/ValueSet/detailed-race
+    binding_version: null
+    description: "[Text representation of Coding] [extension us_core_race] Concepts\
+      \ classifying the person into a named category of humans sharing common history,\
+      \ traits, geographical origin or nationality.  The race codes used to represent\
+      \ these concepts are based upon the [CDC Race and Ethnicity Code Set Version\
+      \ 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes\
+      \ over 900 concepts for representing race and ethnicity of which 921 reference\
+      \ race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\
+      \n - American Indian or Alaska Native\n - Asian\n - Black or African American\n\
+      \ - Native Hawaiian or Other Pacific Islander\n - White."
+    term:
+      description: null
+      termDef:
+        cde_id: http://hl7.org/fhir/us/core/ValueSet/detailed-race
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/us/core/ValueSet/detailed-race
+        term_url: http://hl7.org/fhir/us/core/ValueSet/detailed-race
+    type: string
+  us_core_race_ombCategory:
+    binding_description: The 5 race category codes according to the [OMB Standards
+      for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity,
+      Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/us/core/ValueSet/omb-race-category
+    binding_version: null
+    description: "[Text representation of Coding] [extension us_core_race] Concepts\
+      \ classifying the person into a named category of humans sharing common history,\
+      \ traits, geographical origin or nationality.  The race codes used to represent\
+      \ these concepts are based upon the [CDC Race and Ethnicity Code Set Version\
+      \ 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes\
+      \ over 900 concepts for representing race and ethnicity of which 921 reference\
+      \ race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\
+      \n - American Indian or Alaska Native\n - Asian\n - Black or African American\n\
+      \ - Native Hawaiian or Other Pacific Islander\n - White."
+    term:
+      description: The 5 race category codes according to the [OMB Standards for Maintaining,
+        Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical
+        Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).
+      termDef:
+        cde_id: http://hl7.org/fhir/us/core/ValueSet/omb-race-category
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/us/core/ValueSet/omb-race-category
+        term_url: http://hl7.org/fhir/us/core/ValueSet/omb-race-category
+    type: string
+  us_core_tribal_affiliation_isEnrolled:
+    description: '[extension us_core_tribal_affiliation] This Extension profile represents
+      a tribe or band with which a person associates and, optionally, whether they
+      are enrolled.'
+    type: boolean
+  us_core_tribal_affiliation_tribalAffiliation:
+    binding_description: Tribal Entity recognized by the United States Bureau Of Indian
+      Affairs.
+    binding_strength: extensible
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-TribalEntityUS
+    binding_version: null
+    description: text representation. [extension us_core_tribal_affiliation] This
+      Extension profile represents a tribe or band with which a person associates
+      and, optionally, whether they are enrolled.
+    term:
+      description: Tribal Entity recognized by the United States Bureau Of Indian
+        Affairs.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-TribalEntityUS
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://terminology.hl7.org/ValueSet/v3-TribalEntityUS
+        term_url: http://terminology.hl7.org/ValueSet/v3-TribalEntityUS
+    type: string
+  us_core_tribal_affiliation_tribalAffiliation_coding: &id003
+    binding_description: Tribal Entity recognized by the United States Bureau Of Indian
+      Affairs.
+    binding_strength: extensible
+    binding_uri: http://terminology.hl7.org/ValueSet/v3-TribalEntityUS
+    binding_version: null
+    description: '[system#code representation.] [extension us_core_tribal_affiliation]
+      This Extension profile represents a tribe or band with which a person associates
+      and, optionally, whether they are enrolled.'
+    term:
+      description: Tribal Entity recognized by the United States Bureau Of Indian
+        Affairs.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v3-TribalEntityUS
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://terminology.hl7.org/ValueSet/v3-TribalEntityUS
+        term_url: http://terminology.hl7.org/ValueSet/v3-TribalEntityUS
+    type: string
+  us_core_tribal_affiliation_tribalAffiliation_text: *id003
+title: Patient
+type: object

--- a/tests/integration/data/schemas/practitioner.yaml
+++ b/tests/integration/data/schemas/practitioner.yaml
@@ -1,0 +1,166 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Administrative
+description: A person with a  formal responsibility in the provisioning of healthcare
+  or related services. A person who is directly or indirectly involved in the provisioning
+  of healthcare or related services. [See https://hl7.org/fhir/R5/Practitioner.html]
+id: practitioner
+links: []
+program: '*'
+project: '*'
+properties:
+  active:
+    description: Whether this practitioner's record is in active use
+    element_property: true
+    title: Whether this practitioner's record is in active use
+    type: boolean
+  address:
+    description: '[Text representation of Address] Address(es) of the practitioner
+      that are not role specific (typically home address).  Work addresses are not
+      typically entered in this property as they are usually role dependent.'
+    element_property: true
+    items:
+      type: string
+    title: Address(es) of the practitioner that are not role specific (typically home
+      address)
+    type: array
+  birthDate:
+    description: The date of birth for the practitioner.
+    element_property: true
+    format: date
+    title: The date  on which the practitioner was born
+    type: string
+  communication:
+    description: '[Text representation of PractitionerCommunication] A language which
+      may be used to communicate with the practitioner, often for correspondence/administrative
+      purposes.  The `PractitionerRole.communication` property should be used for
+      publishing the languages that a practitioner is able to communicate with patients
+      (on a per Organization/Role basis).'
+    element_property: true
+    items:
+      type: string
+    title: A language which may be used to communicate with the practitioner
+    type: array
+  deceasedBoolean:
+    description: Indicates if the practitioner is deceased or not
+    element_property: true
+    one_of_many: deceased
+    one_of_many_required: false
+    title: Indicates if the practitioner is deceased or not
+    type: boolean
+  deceasedDateTime:
+    description: Indicates if the practitioner is deceased or not
+    element_property: true
+    format: date-time
+    one_of_many: deceased
+    one_of_many_required: false
+    title: Indicates if the practitioner is deceased or not
+    type: string
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  gender:
+    binding_description: The gender of a person used for administrative purposes.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/administrative-gender
+    binding_version: 5.0.0
+    description: Administrative Gender - the gender that the person is considered
+      to have for administration and record keeping purposes.
+    element_property: true
+    enum_values:
+    - male
+    - female
+    - other
+    - unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: male | female | other | unknown
+    type: string
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: An identifier that applies to this person in this role.
+    element_property: true
+    items:
+      type: string
+    title: An identifier for the person as this agent
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] An identifier that applies
+      to this person in this role.'
+    element_property: true
+    items:
+      type: string
+    title: An identifier for the person as this agent
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] An identifier that
+      applies to this person in this role.'
+    element_property: true
+    items:
+      type: string
+    title: An identifier for the person as this agent
+    type: array
+  name:
+    description: '[Text representation of HumanName] The name(s) associated with the
+      practitioner'
+    element_property: true
+    items:
+      type: string
+    title: The name(s) associated with the practitioner
+    type: array
+  photo:
+    description: '[Text representation of Attachment] Image of the person'
+    element_property: true
+    items:
+      type: string
+    title: Image of the person
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  qualification:
+    description: '[Text representation of PractitionerQualification] The official
+      qualifications, certifications, accreditations, training, licenses (and other
+      types of educations/skills/capabilities) that authorize or otherwise pertain
+      to the provision of care by the practitioner.  For example, a medical license
+      issued by a medical board of licensure authorizing the practitioner to practice
+      medicine within a certain locality.'
+    element_property: true
+    items:
+      type: string
+    title: Qualifications, certifications, accreditations, licenses, training, etc.
+      pertaining to the provision of care
+    type: array
+  resourceType:
+    const: Practitioner
+    default: Practitioner
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  telecom:
+    description: '[Text representation of ContactPoint] A contact detail for the practitioner,
+      e.g. a telephone number or an email address.'
+    element_property: true
+    items:
+      type: string
+    title: A contact detail for the practitioner (that apply to all roles)
+    type: array
+title: Practitioner
+type: object

--- a/tests/integration/data/schemas/practitioner_role.yaml
+++ b/tests/integration/data/schemas/practitioner_role.yaml
@@ -1,0 +1,349 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Administrative
+description: Roles/organizations the practitioner is associated with. A specific set
+  of Roles/Locations/specialties/services that a practitioner may perform at an organization
+  for a period of time. [See https://hl7.org/fhir/R5/PractitionerRole.html]
+id: practitioner_role
+links:
+- backref: location_practitioner_role
+  label: PractitionerRole_location_Location_location_practitioner_role
+  multiplicity: many_to_many
+  name: location
+  required: false
+  target_type: location
+- backref: practitioner_role
+  label: PractitionerRole_organization_Organization_practitioner_role
+  multiplicity: many_to_many
+  name: organization
+  required: false
+  target_type: organization
+- backref: practitioner_role
+  label: PractitionerRole_practitioner_Practitioner_practitioner_role
+  multiplicity: many_to_many
+  name: practitioner
+  required: false
+  target_type: practitioner
+program: '*'
+project: '*'
+properties:
+  active:
+    description: ' Whether this practitioner role record is in active use. Some systems
+      may use this property to mark non-active practitioners, such as those that are
+      not currently employed.'
+    element_property: true
+    title: Whether this practitioner role record is in active use
+    type: boolean
+  availability:
+    description: '[Text representation of Availability] A collection of times the
+      practitioner is available or performing this role at the location and/or healthcareservice.'
+    element_property: true
+    items:
+      type: string
+    title: Times the Practitioner is available at this location and/or healthcare
+      service (including exceptions)
+    type: array
+  characteristic:
+    binding_description: A custom attribute that could be provided at a service (e.g.
+      Wheelchair accessibility).
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/service-mode
+    binding_version: null
+    description: text representation. Collection of characteristics (attributes)
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A custom attribute that could be provided at a service (e.g. Wheelchair
+        accessibility).
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/service-mode
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/service-mode
+        term_url: http://hl7.org/fhir/ValueSet/service-mode
+    title: Collection of characteristics (attributes)
+    type: array
+  characteristic_coding: &id001
+    binding_description: A custom attribute that could be provided at a service (e.g.
+      Wheelchair accessibility).
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/service-mode
+    binding_version: null
+    description: '[system#code representation.] Collection of characteristics (attributes)'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A custom attribute that could be provided at a service (e.g. Wheelchair
+        accessibility).
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/service-mode
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/service-mode
+        term_url: http://hl7.org/fhir/ValueSet/service-mode
+    title: Collection of characteristics (attributes)
+    type: array
+  characteristic_text: *id001
+  code:
+    binding_description: The role a person plays representing an organization.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/practitioner-role
+    binding_version: null
+    description: text representation. Roles which this practitioner is authorized
+      to perform for the organization.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: The role a person plays representing an organization.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/practitioner-role
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/practitioner-role
+        term_url: http://hl7.org/fhir/ValueSet/practitioner-role
+    title: Roles which this practitioner may perform
+    type: array
+  code_coding: &id002
+    binding_description: The role a person plays representing an organization.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/practitioner-role
+    binding_version: null
+    description: '[system#code representation.] Roles which this practitioner is authorized
+      to perform for the organization.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: The role a person plays representing an organization.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/practitioner-role
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/practitioner-role
+        term_url: http://hl7.org/fhir/ValueSet/practitioner-role
+    title: Roles which this practitioner may perform
+    type: array
+  code_text: *id002
+  communication:
+    binding_description: IETF language tag for a human language
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/all-languages
+    binding_version: 5.0.0
+    description: text representation. A language the practitioner can use in patient
+      communication. The practitioner may know several languages (listed in practitioner.communication),
+      however these are the languages that could be advertised in a directory for
+      a patient to search.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: IETF language tag for a human language
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/all-languages
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/ValueSet/all-languages
+        term_url: http://hl7.org/fhir/ValueSet/all-languages
+    title: A language the practitioner (in this role) can use in patient communication
+    type: array
+  communication_coding: &id003
+    binding_description: IETF language tag for a human language
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/all-languages
+    binding_version: 5.0.0
+    description: '[system#code representation.] A language the practitioner can use
+      in patient communication. The practitioner may know several languages (listed
+      in practitioner.communication), however these are the languages that could be
+      advertised in a directory for a patient to search.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: IETF language tag for a human language
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/all-languages
+        cde_version: null
+        source: fhir
+        strength: required
+        term: http://hl7.org/fhir/ValueSet/all-languages
+        term_url: http://hl7.org/fhir/ValueSet/all-languages
+    title: A language the practitioner (in this role) can use in patient communication
+    type: array
+  communication_text: *id003
+  contact:
+    description: '[Text representation of ExtendedContactDetail] The contact details
+      of communication devices available relevant to the specific PractitionerRole.
+      This can include addresses, phone numbers, fax numbers, mobile numbers, email
+      addresses and web sites.'
+    element_property: true
+    items:
+      type: string
+    title: Official contact details relating to this PractitionerRole
+    type: array
+  endpoint:
+    backref: endpoint_practitioner_role
+    description: '[Text representation of Reference]  Technical endpoints providing
+      access to services operated for the practitioner with this role. Commonly used
+      for locating scheduling services, or identifying where to send referrals electronically.'
+    element_property: true
+    enum_reference_types:
+    - Endpoint
+    items:
+      type: string
+    title: Endpoints for interacting with the practitioner in this role
+    type: array
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  healthcareService:
+    backref: healthcareService_practitioner_role
+    description: '[Text representation of Reference] The list of healthcare services
+      that this worker provides for this role''s Organization/Location(s).'
+    element_property: true
+    enum_reference_types:
+    - HealthcareService
+    items:
+      type: string
+    title: Healthcare services provided for this role's Organization/Location(s)
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Business Identifiers that are specific to a role/location.
+    element_property: true
+    items:
+      type: string
+    title: Identifiers for a role/location
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Business Identifiers
+      that are specific to a role/location.'
+    element_property: true
+    items:
+      type: string
+    title: Identifiers for a role/location
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Business Identifiers
+      that are specific to a role/location.'
+    element_property: true
+    items:
+      type: string
+    title: Identifiers for a role/location
+    type: array
+  location:
+    backref: location_practitioner_role
+    description: '[Text representation of Reference] The location(s) at which this
+      practitioner provides care.'
+    element_property: true
+    enum_reference_types:
+    - Location
+    items:
+      type: string
+    title: Location(s) where the practitioner provides care
+    type: array
+  organization:
+    backref: practitioner_role
+    description: '[Text representation of Reference] The organization where the Practitioner
+      performs the roles associated.'
+    element_property: true
+    enum_reference_types:
+    - Organization
+    title: Organization where the roles are available
+    type: string
+  period:
+    description: '[Text representation of Period] The period during which the person
+      is authorized to act as a practitioner in these role(s) for the organization.'
+    element_property: true
+    title: The period during which the practitioner is authorized to perform in these
+      role(s)
+    type: string
+  practitioner:
+    backref: practitioner_role
+    description: '[Text representation of Reference] Practitioner that is able to
+      provide the defined services for the organization.'
+    element_property: true
+    enum_reference_types:
+    - Practitioner
+    title: Practitioner that provides services for the organization
+    type: string
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  resourceType:
+    const: PractitionerRole
+    default: PractitionerRole
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  specialty:
+    binding_description: Specific specialty associated with the agency.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/c80-practice-codes
+    binding_version: null
+    description: text representation. The specialty of a practitioner that describes
+      the functional role they are practicing at a given organization or location.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Specific specialty associated with the agency.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/c80-practice-codes
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/c80-practice-codes
+        term_url: http://hl7.org/fhir/ValueSet/c80-practice-codes
+    title: Specific specialty of the practitioner
+    type: array
+  specialty_coding: &id004
+    binding_description: Specific specialty associated with the agency.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/c80-practice-codes
+    binding_version: null
+    description: '[system#code representation.] The specialty of a practitioner that
+      describes the functional role they are practicing at a given organization or
+      location.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Specific specialty associated with the agency.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/c80-practice-codes
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/c80-practice-codes
+        term_url: http://hl7.org/fhir/ValueSet/c80-practice-codes
+    title: Specific specialty of the practitioner
+    type: array
+  specialty_text: *id004
+title: PractitionerRole
+type: object

--- a/tests/integration/data/schemas/procedure.yaml
+++ b/tests/integration/data/schemas/procedure.yaml
@@ -1,0 +1,883 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: An action that is being or was performed on an individual or entity.
+  An action that is or was performed on or for a patient, practitioner, device, organization,
+  or location. For example, this can be a physical intervention on a patient like
+  an operation, or less invasive like long term services, counseling, or hypnotherapy.  This
+  can be a quality or safety inspection for a location, organization, or device.  This
+  can be an accreditation procedure on a practitioner for licensing. [See https://hl7.org/fhir/R5/Procedure.html]
+id: procedure
+links:
+- backref: subject_procedure
+  label: Procedure_subject_Patient_subject_procedure
+  multiplicity: many_to_many
+  name: subject_Patient
+  required: false
+  target_type: patient
+- backref: subject_procedure
+  label: Procedure_subject_Practitioner_subject_procedure
+  multiplicity: many_to_many
+  name: subject_Practitioner
+  required: false
+  target_type: practitioner
+- backref: subject_procedure
+  label: Procedure_subject_Organization_subject_procedure
+  multiplicity: many_to_many
+  name: subject_Organization
+  required: false
+  target_type: organization
+- backref: subject_procedure
+  label: Procedure_subject_Location_subject_procedure
+  multiplicity: many_to_many
+  name: subject_Location
+  required: false
+  target_type: location
+- backref: complication_procedure
+  label: Procedure_complication_Condition_complication_procedure
+  multiplicity: many_to_many
+  name: complication
+  required: false
+  target_type: condition
+- backref: procedure
+  label: Procedure_encounter_Encounter_procedure
+  multiplicity: many_to_many
+  name: encounter
+  required: false
+  target_type: encounter
+- backref: focus_procedure
+  label: Procedure_focus_PractitionerRole_focus_procedure
+  multiplicity: many_to_many
+  name: focus_PractitionerRole
+  required: false
+  target_type: practitioner_role
+- backref: focus_procedure
+  label: Procedure_focus_Specimen_focus_procedure
+  multiplicity: many_to_many
+  name: focus_Specimen
+  required: false
+  target_type: specimen
+- backref: partOf_procedure
+  label: Procedure_partOf_Procedure_partOf_procedure
+  multiplicity: many_to_many
+  name: partOf_Procedure
+  required: false
+  target_type: procedure
+- backref: partOf_procedure
+  label: Procedure_partOf_Observation_partOf_procedure
+  multiplicity: many_to_many
+  name: partOf_Observation
+  required: false
+  target_type: observation
+- backref: partOf_procedure
+  label: Procedure_partOf_MedicationAdministration_partOf_procedure
+  multiplicity: many_to_many
+  name: partOf_MedicationAdministration
+  required: false
+  target_type: medication_administration
+- backref: reason_procedure
+  label: Procedure_reason_DiagnosticReport_reason_procedure
+  multiplicity: many_to_many
+  name: reason_DiagnosticReport
+  required: false
+  target_type: diagnostic_report
+- backref: reason_procedure
+  label: Procedure_reason_DocumentReference_reason_procedure
+  multiplicity: many_to_many
+  name: reason_DocumentReference
+  required: false
+  target_type: document_reference
+- backref: used_procedure
+  label: Procedure_used_Medication_used_procedure
+  multiplicity: many_to_many
+  name: used_Medication
+  required: false
+  target_type: medication
+- backref: used_procedure
+  label: Procedure_used_Substance_used_procedure
+  multiplicity: many_to_many
+  name: used_Substance
+  required: false
+  target_type: substance
+program: '*'
+project: '*'
+properties:
+  basedOn:
+    backref: basedOn_procedure
+    description: '[Text representation of Reference] A reference to a resource that
+      contains details of the request for this procedure.'
+    element_property: true
+    enum_reference_types:
+    - CarePlan
+    - ServiceRequest
+    items:
+      type: string
+    title: A request for this procedure
+    type: array
+  bodySite:
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: text representation. Detailed and structured anatomical location
+      information. Multiple locations are allowed - e.g. multiple punch biopsies of
+      a lesion.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Target body sites
+    type: array
+  bodySite_coding: &id001
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: '[system#code representation.] Detailed and structured anatomical
+      location information. Multiple locations are allowed - e.g. multiple punch biopsies
+      of a lesion.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Target body sites
+    type: array
+  bodySite_text: *id001
+  category:
+    binding_description: A code that classifies a procedure for searching, sorting
+      and display purposes.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-category
+    binding_version: null
+    description: text representation. A code that classifies the procedure for searching,
+      sorting and display purposes (e.g. "Surgical Procedure").
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A code that classifies a procedure for searching, sorting and display
+        purposes.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-category
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-category
+        term_url: http://hl7.org/fhir/ValueSet/procedure-category
+    title: Classification of the procedure
+    type: array
+  category_coding: &id002
+    binding_description: A code that classifies a procedure for searching, sorting
+      and display purposes.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-category
+    binding_version: null
+    description: '[system#code representation.] A code that classifies the procedure
+      for searching, sorting and display purposes (e.g. "Surgical Procedure").'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: A code that classifies a procedure for searching, sorting and display
+        purposes.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-category
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-category
+        term_url: http://hl7.org/fhir/ValueSet/procedure-category
+    title: Classification of the procedure
+    type: array
+  category_text: *id002
+  code:
+    binding_description: A code to identify a specific procedure .
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-code
+    binding_version: null
+    description: text representation. The specific procedure that is performed. Use
+      text if the exact nature of the procedure cannot be coded (e.g. "Laparoscopic
+      Appendectomy").
+    element_property: true
+    term:
+      description: A code to identify a specific procedure .
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-code
+        term_url: http://hl7.org/fhir/ValueSet/procedure-code
+    title: Identification of the procedure
+    type: string
+  code_coding: &id003
+    binding_description: A code to identify a specific procedure .
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-code
+    binding_version: null
+    description: '[system#code representation.] The specific procedure that is performed.
+      Use text if the exact nature of the procedure cannot be coded (e.g. "Laparoscopic
+      Appendectomy").'
+    element_property: true
+    term:
+      description: A code to identify a specific procedure .
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-code
+        term_url: http://hl7.org/fhir/ValueSet/procedure-code
+    title: Identification of the procedure
+    type: string
+  code_text: *id003
+  complication:
+    backref: complication_procedure
+    binding_description: Codes describing complications that resulted from a procedure.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-code
+    binding_version: null
+    description: text representation. Any complications that occurred during the procedure,
+      or in the immediate post-performance period. These are generally tracked separately
+      from the notes, which will typically describe the procedure itself rather than
+      any 'post procedure' issues.
+    element_property: true
+    enum_reference_types:
+    - Condition
+    items:
+      type: string
+    term:
+      description: Codes describing complications that resulted from a procedure.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/condition-code
+        term_url: http://hl7.org/fhir/ValueSet/condition-code
+    title: Complication following the procedure
+    type: array
+  complication_coding: &id004
+    backref: complication_procedure
+    binding_description: Codes describing complications that resulted from a procedure.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-code
+    binding_version: null
+    description: '[system#code representation.] Any complications that occurred during
+      the procedure, or in the immediate post-performance period. These are generally
+      tracked separately from the notes, which will typically describe the procedure
+      itself rather than any ''post procedure'' issues.'
+    element_property: true
+    enum_reference_types:
+    - Condition
+    items:
+      type: string
+    term:
+      description: Codes describing complications that resulted from a procedure.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/condition-code
+        term_url: http://hl7.org/fhir/ValueSet/condition-code
+    title: Complication following the procedure
+    type: array
+  complication_text: *id004
+  encounter:
+    backref: procedure
+    description: '[Text representation of Reference] The Encounter during which this
+      Procedure was created or performed or to which the creation of this record is
+      tightly associated.'
+    element_property: true
+    enum_reference_types:
+    - Encounter
+    title: The Encounter during which this Procedure was created
+    type: string
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  focalDevice:
+    description: '[Text representation of ProcedureFocalDevice] A device that is implanted,
+      removed or otherwise manipulated (calibration, battery replacement, fitting
+      a prosthesis, attaching a wound-vac, etc.) as a focal portion of the Procedure.'
+    element_property: true
+    items:
+      type: string
+    title: Manipulated, implanted, or removed device
+    type: array
+  focus:
+    backref: focus_procedure
+    description: '[Text representation of Reference] Who is the target of the procedure
+      when it is not the subject of record only.  If focus is not present, then subject
+      is the focus.  If focus is present and the subject is one of the targets of
+      the procedure, include subject as a focus as well. If focus is present and the
+      subject is not included in focus, it implies that the procedure was only targeted
+      on the focus. For example, when a caregiver is given education for a patient,
+      the caregiver would be the focus and the procedure record is associated with
+      the subject (e.g. patient).  For example, use focus when recording the target
+      of the education, training, or counseling is the parent or relative of a patient.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Group
+    - RelatedPerson
+    - Practitioner
+    - Organization
+    - CareTeam
+    - PractitionerRole
+    - Specimen
+    title: Who is the target of the procedure when it is not the subject of record
+      only
+    type: string
+  followUp:
+    binding_description: Specific follow up required for a procedure e.g. removal
+      of sutures.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-followup
+    binding_version: null
+    description: text representation. If the procedure required specific follow up
+      - e.g. removal of sutures. The follow up may be represented as a simple note
+      or could potentially be more complex, in which case the CarePlan resource can
+      be used.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Specific follow up required for a procedure e.g. removal of sutures.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-followup
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-followup
+        term_url: http://hl7.org/fhir/ValueSet/procedure-followup
+    title: Instructions for follow up
+    type: array
+  followUp_coding: &id005
+    binding_description: Specific follow up required for a procedure e.g. removal
+      of sutures.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-followup
+    binding_version: null
+    description: '[system#code representation.] If the procedure required specific
+      follow up - e.g. removal of sutures. The follow up may be represented as a simple
+      note or could potentially be more complex, in which case the CarePlan resource
+      can be used.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Specific follow up required for a procedure e.g. removal of sutures.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-followup
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-followup
+        term_url: http://hl7.org/fhir/ValueSet/procedure-followup
+    title: Instructions for follow up
+    type: array
+  followUp_text: *id005
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Business identifiers assigned to this procedure by the performer
+      or other systems which remain constant as the resource is updated and is propagated
+      from server to server.
+    element_property: true
+    items:
+      type: string
+    title: External Identifiers for this procedure
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Business identifiers
+      assigned to this procedure by the performer or other systems which remain constant
+      as the resource is updated and is propagated from server to server.'
+    element_property: true
+    items:
+      type: string
+    title: External Identifiers for this procedure
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Business identifiers
+      assigned to this procedure by the performer or other systems which remain constant
+      as the resource is updated and is propagated from server to server.'
+    element_property: true
+    items:
+      type: string
+    title: External Identifiers for this procedure
+    type: array
+  instantiatesCanonical:
+    description: The URL pointing to a FHIR-defined protocol, guideline, order set
+      or other definition that is adhered to in whole or in part by this Procedure.
+    element_property: true
+    enum_reference_types:
+    - PlanDefinition
+    - ActivityDefinition
+    - Measure
+    - OperationDefinition
+    - Questionnaire
+    items:
+      pattern: \S*
+      type: string
+    title: Instantiates FHIR protocol or definition
+    type: array
+  instantiatesUri:
+    description: The URL pointing to an externally maintained protocol, guideline,
+      order set or other definition that is adhered to in whole or in part by this
+      Procedure.
+    element_property: true
+    items:
+      pattern: \S*
+      type: string
+    title: Instantiates external protocol or definition
+    type: array
+  location:
+    backref: location_procedure
+    description: '[Text representation of Reference] The location where the procedure
+      actually happened.  E.g. a newborn at home, a tracheostomy at a restaurant.'
+    element_property: true
+    enum_reference_types:
+    - Location
+    title: Where the procedure happened
+    type: string
+  note:
+    description: '[Text representation of Annotation] Any other notes and comments
+      about the procedure.'
+    element_property: true
+    items:
+      type: string
+    title: Additional information about the procedure
+    type: array
+  occurrenceAge:
+    description: '[Text representation of Age] Estimated or actual date, date-time,
+      period, or age when the procedure did occur or is occurring.  Allows a period
+      to support complex procedures that span more than one date, and also allows
+      for the length of the procedure to be captured.'
+    element_property: true
+    one_of_many: occurrence
+    one_of_many_required: false
+    title: When the procedure occurred or is occurring
+    type: string
+  occurrenceDateTime:
+    description: Estimated or actual date, date-time, period, or age when the procedure
+      did occur or is occurring.  Allows a period to support complex procedures that
+      span more than one date, and also allows for the length of the procedure to
+      be captured.
+    element_property: true
+    format: date-time
+    one_of_many: occurrence
+    one_of_many_required: false
+    title: When the procedure occurred or is occurring
+    type: string
+  occurrencePeriod:
+    description: '[Text representation of Period] Estimated or actual date, date-time,
+      period, or age when the procedure did occur or is occurring.  Allows a period
+      to support complex procedures that span more than one date, and also allows
+      for the length of the procedure to be captured.'
+    element_property: true
+    one_of_many: occurrence
+    one_of_many_required: false
+    title: When the procedure occurred or is occurring
+    type: string
+  occurrenceRange:
+    description: '[Text representation of Range] Estimated or actual date, date-time,
+      period, or age when the procedure did occur or is occurring.  Allows a period
+      to support complex procedures that span more than one date, and also allows
+      for the length of the procedure to be captured.'
+    element_property: true
+    one_of_many: occurrence
+    one_of_many_required: false
+    title: When the procedure occurred or is occurring
+    type: string
+  occurrenceString:
+    description: Estimated or actual date, date-time, period, or age when the procedure
+      did occur or is occurring.  Allows a period to support complex procedures that
+      span more than one date, and also allows for the length of the procedure to
+      be captured.
+    element_property: true
+    one_of_many: occurrence
+    one_of_many_required: false
+    pattern: '[ \r\n\t\S]+'
+    title: When the procedure occurred or is occurring
+    type: string
+  occurrenceTiming:
+    description: '[Text representation of Timing] Estimated or actual date, date-time,
+      period, or age when the procedure did occur or is occurring.  Allows a period
+      to support complex procedures that span more than one date, and also allows
+      for the length of the procedure to be captured.'
+    element_property: true
+    one_of_many: occurrence
+    one_of_many_required: false
+    title: When the procedure occurred or is occurring
+    type: string
+  outcome:
+    binding_description: An outcome of a procedure - whether it was resolved or otherwise.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-outcome
+    binding_version: null
+    description: text representation. The outcome of the procedure - did it resolve
+      the reasons for the procedure being performed?
+    element_property: true
+    term:
+      description: An outcome of a procedure - whether it was resolved or otherwise.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-outcome
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-outcome
+        term_url: http://hl7.org/fhir/ValueSet/procedure-outcome
+    title: The result of procedure
+    type: string
+  outcome_coding: &id006
+    binding_description: An outcome of a procedure - whether it was resolved or otherwise.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-outcome
+    binding_version: null
+    description: '[system#code representation.] The outcome of the procedure - did
+      it resolve the reasons for the procedure being performed?'
+    element_property: true
+    term:
+      description: An outcome of a procedure - whether it was resolved or otherwise.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-outcome
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-outcome
+        term_url: http://hl7.org/fhir/ValueSet/procedure-outcome
+    title: The result of procedure
+    type: string
+  outcome_text: *id006
+  partOf:
+    backref: partOf_procedure
+    description: '[Text representation of Reference] A larger event of which this
+      particular procedure is a component or step.'
+    element_property: true
+    enum_reference_types:
+    - Procedure
+    - Observation
+    - MedicationAdministration
+    items:
+      type: string
+    title: Part of referenced event
+    type: array
+  performer:
+    description: '[Text representation of ProcedurePerformer] Indicates who or what
+      performed the procedure and how they were involved.'
+    element_property: true
+    items:
+      type: string
+    title: Who performed the procedure and what they did
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  reason:
+    backref: reason_procedure
+    binding_description: A code that identifies the reason a procedure is  required.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-reason
+    binding_version: null
+    description: text representation. The coded reason or reference why the procedure
+      was performed. This may be a coded entity of some type, be present as text,
+      or be a reference to one of several resources that justify the procedure.
+    element_property: true
+    enum_reference_types:
+    - Condition
+    - Observation
+    - Procedure
+    - DiagnosticReport
+    - DocumentReference
+    items:
+      type: string
+    term:
+      description: A code that identifies the reason a procedure is  required.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-reason
+        term_url: http://hl7.org/fhir/ValueSet/procedure-reason
+    title: The justification that the procedure was performed
+    type: array
+  reason_coding: &id007
+    backref: reason_procedure
+    binding_description: A code that identifies the reason a procedure is  required.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-reason
+    binding_version: null
+    description: '[system#code representation.] The coded reason or reference why
+      the procedure was performed. This may be a coded entity of some type, be present
+      as text, or be a reference to one of several resources that justify the procedure.'
+    element_property: true
+    enum_reference_types:
+    - Condition
+    - Observation
+    - Procedure
+    - DiagnosticReport
+    - DocumentReference
+    items:
+      type: string
+    term:
+      description: A code that identifies the reason a procedure is  required.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-reason
+        term_url: http://hl7.org/fhir/ValueSet/procedure-reason
+    title: The justification that the procedure was performed
+    type: array
+  reason_text: *id007
+  recorded:
+    description: The date the occurrence of the procedure was first captured in the
+      record regardless of Procedure.status (potentially after the occurrence of the
+      event).
+    element_property: true
+    format: date-time
+    title: When the procedure was first captured in the subject's record
+    type: string
+  recorder:
+    backref: recorder_procedure
+    description: '[Text representation of Reference] Individual who recorded the record
+      and takes responsibility for its content.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - RelatedPerson
+    - Practitioner
+    - PractitionerRole
+    title: Who recorded the procedure
+    type: string
+  report:
+    backref: report_procedure
+    description: '[Text representation of Reference] This could be a histology result,
+      pathology report, surgical report, etc.'
+    element_property: true
+    enum_reference_types:
+    - DiagnosticReport
+    - DocumentReference
+    - Composition
+    items:
+      type: string
+    title: Any report resulting from the procedure
+    type: array
+  reportedBoolean:
+    description: Indicates if this record was captured as a secondary 'reported' record
+      rather than as an original primary source-of-truth record.  It may also indicate
+      the source of the report.
+    element_property: true
+    one_of_many: reported
+    one_of_many_required: false
+    title: Reported rather than primary record
+    type: boolean
+  reportedReference:
+    backref: reportedReference_procedure
+    description: '[Text representation of Reference] Indicates if this record was
+      captured as a secondary ''reported'' record rather than as an original primary
+      source-of-truth record.  It may also indicate the source of the report.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - RelatedPerson
+    - Practitioner
+    - PractitionerRole
+    - Organization
+    one_of_many: reported
+    one_of_many_required: false
+    title: Reported rather than primary record
+    type: string
+  resourceType:
+    const: Procedure
+    default: Procedure
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  status:
+    binding_description: A code specifying the state of the procedure.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/event-status
+    binding_version: 5.0.0
+    description: A code specifying the state of the procedure. Generally, this will
+      be the in-progress or completed state.
+    element_property: true
+    element_required: true
+    enum_values:
+    - preparation
+    - in-progress
+    - not-done
+    - on-hold
+    - stopped
+    - completed
+    - entered-in-error
+    - unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: preparation | in-progress | not-done | on-hold | stopped | completed |
+      entered-in-error | unknown
+    type: string
+  statusReason:
+    binding_description: A code that identifies the reason a procedure was not performed.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
+    binding_version: null
+    description: text representation. Captures the reason for the current state of
+      the procedure.
+    element_property: true
+    term:
+      description: A code that identifies the reason a procedure was not performed.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
+        term_url: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
+    title: Reason for current status
+    type: string
+  statusReason_coding: &id008
+    binding_description: A code that identifies the reason a procedure was not performed.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
+    binding_version: null
+    description: '[system#code representation.] Captures the reason for the current
+      state of the procedure.'
+    element_property: true
+    term:
+      description: A code that identifies the reason a procedure was not performed.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
+        term_url: http://hl7.org/fhir/ValueSet/procedure-not-performed-reason
+    title: Reason for current status
+    type: string
+  statusReason_text: *id008
+  subject:
+    backref: subject_procedure
+    description: '[Text representation of Reference] On whom or on what the procedure
+      was performed. This is usually an individual human, but can also be performed
+      on animals, groups of humans or animals, organizations or practitioners (for
+      licensing), locations or devices (for safety inspections or regulatory authorizations).  If
+      the actual focus of the procedure is different from the subject, the focus element
+      specifies the actual focus of the procedure.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Group
+    - Device
+    - Practitioner
+    - Organization
+    - Location
+    title: Individual or entity the procedure was performed on
+    type: string
+  supportingInfo:
+    backref: supportingInfo_procedure
+    description: '[Text representation of Reference] Other resources from the patient
+      record that may be relevant to the procedure.  The information from these resources
+      was either used to create the instance or is provided to help with its interpretation.
+      This extension should not be used if more specific inline elements or extensions
+      are available.'
+    element_property: true
+    enum_reference_types:
+    - Resource
+    items:
+      type: string
+    title: Extra information relevant to the procedure
+    type: array
+  used:
+    backref: used_procedure
+    binding_description: Codes describing items used during a procedure.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/device-type
+    binding_version: null
+    description: text representation. Identifies medications, devices and any other
+      substance used as part of the procedure.
+    element_property: true
+    enum_reference_types:
+    - Device
+    - Medication
+    - Substance
+    - BiologicallyDerivedProduct
+    items:
+      type: string
+    term:
+      description: Codes describing items used during a procedure.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/device-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/device-type
+        term_url: http://hl7.org/fhir/ValueSet/device-type
+    title: Items used during procedure
+    type: array
+  used_coding: &id009
+    backref: used_procedure
+    binding_description: Codes describing items used during a procedure.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/device-type
+    binding_version: null
+    description: '[system#code representation.] Identifies medications, devices and
+      any other substance used as part of the procedure.'
+    element_property: true
+    enum_reference_types:
+    - Device
+    - Medication
+    - Substance
+    - BiologicallyDerivedProduct
+    items:
+      type: string
+    term:
+      description: Codes describing items used during a procedure.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/device-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/device-type
+        term_url: http://hl7.org/fhir/ValueSet/device-type
+    title: Items used during procedure
+    type: array
+  used_text: *id009
+title: Procedure
+type: object

--- a/tests/integration/data/schemas/research_study.yaml
+++ b/tests/integration/data/schemas/research_study.yaml
@@ -1,0 +1,704 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Administrative
+description: Investigation to increase healthcare-related patient-independent knowledge.
+  A scientific study of nature that sometimes includes processes involved in health
+  and disease. For example, clinical trials are research studies that involve people.
+  These studies may be related to new ways to screen, prevent, diagnose, and treat
+  disease. They may also study certain outcomes and certain groups of people by looking
+  at data collected in the past or future. [See https://hl7.org/fhir/R5/ResearchStudy.html]
+id: research_study
+links:
+- backref: focus_research_study
+  label: ResearchStudy_focus_Medication_focus_research_study
+  multiplicity: many_to_many
+  name: focus_Medication
+  required: false
+  target_type: medication
+- backref: partOf_research_study
+  label: ResearchStudy_partOf_ResearchStudy_partOf_research_study
+  multiplicity: many_to_many
+  name: partOf
+  required: false
+  target_type: research_study
+- backref: result_research_study
+  label: ResearchStudy_result_DiagnosticReport_result_research_study
+  multiplicity: many_to_many
+  name: result_DiagnosticReport
+  required: false
+  target_type: diagnostic_report
+- backref: site_research_study
+  label: ResearchStudy_site_Location_site_research_study
+  multiplicity: many_to_many
+  name: site_Location
+  required: false
+  target_type: location
+- backref: site_research_study
+  label: ResearchStudy_site_Organization_site_research_study
+  multiplicity: many_to_many
+  name: site_Organization
+  required: false
+  target_type: organization
+- backref: research_study
+  label: ResearchStudy_gen3_project_Project_research_study
+  multiplicity: many_to_many
+  name: gen3_project
+  required: false
+  target_type: project
+program: '*'
+project: '*'
+properties:
+  associatedParty:
+    description: '[Text representation of ResearchStudyAssociatedParty] Sponsors,
+      collaborators, and other parties'
+    element_property: true
+    items:
+      type: string
+    title: Sponsors, collaborators, and other parties
+    type: array
+  classifier:
+    binding_description: desc.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-classifiers
+    binding_version: null
+    description: 'text representation. Additional grouping mechanism or categorization
+      of a research study. Example: FDA regulated device, FDA regulated drug, MPG
+      Paragraph 23b (a German legal requirement), IRB-exempt, etc. Implementation
+      Note: do not use the classifier element to support existing semantics that are
+      already supported thru explicit elements in the resource.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: desc.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-classifiers
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/research-study-classifiers
+        term_url: http://hl7.org/fhir/ValueSet/research-study-classifiers
+    title: Classification for the study
+    type: array
+  classifier_coding: &id001
+    binding_description: desc.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-classifiers
+    binding_version: null
+    description: '[system#code representation.] Additional grouping mechanism or categorization
+      of a research study. Example: FDA regulated device, FDA regulated drug, MPG
+      Paragraph 23b (a German legal requirement), IRB-exempt, etc. Implementation
+      Note: do not use the classifier element to support existing semantics that are
+      already supported thru explicit elements in the resource.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: desc.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-classifiers
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/research-study-classifiers
+        term_url: http://hl7.org/fhir/ValueSet/research-study-classifiers
+    title: Classification for the study
+    type: array
+  classifier_text: *id001
+  comparisonGroup:
+    description: '[Text representation of ResearchStudyComparisonGroup] Describes
+      an expected event or sequence of events for one of the subjects of a study.
+      E.g. for a living subject: exposure to drug A, wash-out, exposure to drug B,
+      wash-out, follow-up. E.g. for a stability study: {store sample from lot A at
+      25 degrees for 1 month}, {store sample from lot A at 40 degrees for 1 month}.'
+    element_property: true
+    items:
+      type: string
+    title: Defined path through the study for a subject
+    type: array
+  condition:
+    binding_description: Identification of the condition or diagnosis.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-code
+    binding_version: null
+    description: text representation. The condition that is the focus of the study.  For
+      example, In a study to examine risk factors for Lupus, might have as an inclusion
+      criterion "healthy volunteer", but the target condition code would be a Lupus
+      SNOMED code.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Identification of the condition or diagnosis.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/condition-code
+        term_url: http://hl7.org/fhir/ValueSet/condition-code
+    title: Condition being studied
+    type: array
+  condition_coding: &id002
+    binding_description: Identification of the condition or diagnosis.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/condition-code
+    binding_version: null
+    description: '[system#code representation.] The condition that is the focus of
+      the study.  For example, In a study to examine risk factors for Lupus, might
+      have as an inclusion criterion "healthy volunteer", but the target condition
+      code would be a Lupus SNOMED code.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Identification of the condition or diagnosis.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/condition-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/condition-code
+        term_url: http://hl7.org/fhir/ValueSet/condition-code
+    title: Condition being studied
+    type: array
+  condition_text: *id002
+  date:
+    description: The date (and optionally time) when the ResearchStudy Resource was
+      last significantly changed. The date must change when the business version changes
+      and it must change if the status code changes. In addition, it should change
+      when the substantive content of the ResearchStudy Resource changes.
+    element_property: true
+    format: date-time
+    title: Date the resource last changed
+    type: string
+  description:
+    description: A detailed and human-readable narrative of the study. E.g., study
+      abstract.
+    element_property: true
+    pattern: \s*(\S|\s)*
+    title: Detailed narrative of the study
+    type: string
+  descriptionSummary:
+    description: A brief text for explaining the study.
+    element_property: true
+    pattern: \s*(\S|\s)*
+    title: Brief text explaining the study
+    type: string
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  focus:
+    backref: focus_research_study
+    binding_description: Common codes of research study focus
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-focus-type
+    binding_version: null
+    description: text representation. The medication(s), food(s), therapy(ies), device(s)
+      or other concerns or interventions that the study is seeking to gain more information
+      about.
+    element_property: true
+    enum_reference_types:
+    - Medication
+    - MedicinalProductDefinition
+    - SubstanceDefinition
+    - EvidenceVariable
+    items:
+      type: string
+    term:
+      description: Common codes of research study focus
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-focus-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/research-study-focus-type
+        term_url: http://hl7.org/fhir/ValueSet/research-study-focus-type
+    title: Drugs, devices, etc. under study
+    type: array
+  focus_coding: &id003
+    backref: focus_research_study
+    binding_description: Common codes of research study focus
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-focus-type
+    binding_version: null
+    description: '[system#code representation.] The medication(s), food(s), therapy(ies),
+      device(s) or other concerns or interventions that the study is seeking to gain
+      more information about.'
+    element_property: true
+    enum_reference_types:
+    - Medication
+    - MedicinalProductDefinition
+    - SubstanceDefinition
+    - EvidenceVariable
+    items:
+      type: string
+    term:
+      description: Common codes of research study focus
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-focus-type
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/research-study-focus-type
+        term_url: http://hl7.org/fhir/ValueSet/research-study-focus-type
+    title: Drugs, devices, etc. under study
+    type: array
+  focus_text: *id003
+  gen3_project:
+    backref: research_study
+    description: '[Text representation of Reference] The Gen3 project this study belongs
+      to.  Used to generate link.'
+    enum_reference_types:
+    - Project
+    title: The Gen3 project this study belongs to.
+    type: string
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Identifiers assigned to this research study by the sponsor or other
+      systems.
+    element_property: true
+    items:
+      type: string
+    title: Business Identifier for study
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Identifiers assigned
+      to this research study by the sponsor or other systems.'
+    element_property: true
+    items:
+      type: string
+    title: Business Identifier for study
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Identifiers assigned
+      to this research study by the sponsor or other systems.'
+    element_property: true
+    items:
+      type: string
+    title: Business Identifier for study
+    type: array
+  keyword:
+    description: text representation. Key terms to aid in searching for or filtering
+      the study.
+    element_property: true
+    items:
+      type: string
+    title: Used to search for the study
+    type: array
+  keyword_coding: &id004
+    description: '[system#code representation.] Key terms to aid in searching for
+      or filtering the study.'
+    element_property: true
+    items:
+      type: string
+    title: Used to search for the study
+    type: array
+  keyword_text: *id004
+  label_:
+    description: '[Text representation of ResearchStudyLabel] Additional names for
+      the study'
+    element_property: true
+    items:
+      type: string
+    title: Additional names for the study
+    type: array
+  name:
+    description: Name for this study (computer friendly)
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: Name for this study (computer friendly)
+    type: string
+  note:
+    description: '[Text representation of Annotation] Comments made about the study
+      by the performer, subject or other participants.'
+    element_property: true
+    items:
+      type: string
+    title: Comments made about the study
+    type: array
+  objective:
+    description: '[Text representation of ResearchStudyObjective] A goal that the
+      study is aiming to achieve in terms of a scientific question to be answered
+      by the analysis of data collected during the study.'
+    element_property: true
+    items:
+      type: string
+    title: A goal for the study
+    type: array
+  outcomeMeasure:
+    description: '[Text representation of ResearchStudyOutcomeMeasure] An "outcome
+      measure", "endpoint", "effect measure" or "measure of effect" is a specific
+      measurement or observation used to quantify the effect of experimental variables
+      on the participants in a study, or for observational studies, to describe patterns
+      of diseases or traits or associations with exposures, risk factors or treatment.'
+    element_property: true
+    items:
+      type: string
+    title: A variable measured during the study
+    type: array
+  partOf:
+    backref: partOf_research_study
+    description: '[Text representation of Reference] A larger research study of which
+      this particular study is a component or step.'
+    element_property: true
+    enum_reference_types:
+    - ResearchStudy
+    items:
+      type: string
+    title: Part of larger study
+    type: array
+  period:
+    description: '[Text representation of Period] Identifies the start date and the
+      expected (or actual, depending on status) end date for the study.'
+    element_property: true
+    title: When the study began and ended
+    type: string
+  phase:
+    binding_description: Codes for the stage in the progression of a therapy from
+      initial experimental use in humans in clinical trials to post-market evaluation.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-phase
+    binding_version: null
+    description: text representation. The stage in the progression of a therapy from
+      initial experimental use in humans in clinical trials to post-market evaluation.
+    element_property: true
+    term:
+      description: Codes for the stage in the progression of a therapy from initial
+        experimental use in humans in clinical trials to post-market evaluation.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-phase
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/research-study-phase
+        term_url: http://hl7.org/fhir/ValueSet/research-study-phase
+    title: n-a | early-phase-1 | phase-1 | phase-1-phase-2 | phase-2 | phase-2-phase-3
+      | phase-3 | phase-4
+    type: string
+  phase_coding: &id005
+    binding_description: Codes for the stage in the progression of a therapy from
+      initial experimental use in humans in clinical trials to post-market evaluation.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-phase
+    binding_version: null
+    description: '[system#code representation.] The stage in the progression of a
+      therapy from initial experimental use in humans in clinical trials to post-market
+      evaluation.'
+    element_property: true
+    term:
+      description: Codes for the stage in the progression of a therapy from initial
+        experimental use in humans in clinical trials to post-market evaluation.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-phase
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/research-study-phase
+        term_url: http://hl7.org/fhir/ValueSet/research-study-phase
+    title: n-a | early-phase-1 | phase-1 | phase-1-phase-2 | phase-2 | phase-2-phase-3
+      | phase-3 | phase-4
+    type: string
+  phase_text: *id005
+  primaryPurposeType:
+    binding_description: Codes for the main intent of the study.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-prim-purp-type
+    binding_version: null
+    description: text representation. The type of study based upon the intent of the
+      study activities. A classification of the intent of the study.
+    element_property: true
+    term:
+      description: Codes for the main intent of the study.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-prim-purp-type
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/research-study-prim-purp-type
+        term_url: http://hl7.org/fhir/ValueSet/research-study-prim-purp-type
+    title: treatment | prevention | diagnostic | supportive-care | screening | health-services-research
+      | basic-science | device-feasibility
+    type: string
+  primaryPurposeType_coding: &id006
+    binding_description: Codes for the main intent of the study.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-prim-purp-type
+    binding_version: null
+    description: '[system#code representation.] The type of study based upon the intent
+      of the study activities. A classification of the intent of the study.'
+    element_property: true
+    term:
+      description: Codes for the main intent of the study.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-prim-purp-type
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/research-study-prim-purp-type
+        term_url: http://hl7.org/fhir/ValueSet/research-study-prim-purp-type
+    title: treatment | prevention | diagnostic | supportive-care | screening | health-services-research
+      | basic-science | device-feasibility
+    type: string
+  primaryPurposeType_text: *id006
+  progressStatus:
+    description: '[Text representation of ResearchStudyProgressStatus] Status of study
+      with time for that status'
+    element_property: true
+    items:
+      type: string
+    title: Status of study with time for that status
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  protocol:
+    backref: protocol_research_study
+    description: '[Text representation of Reference] The set of steps expected to
+      be performed as part of the execution of the study.'
+    element_property: true
+    enum_reference_types:
+    - PlanDefinition
+    items:
+      type: string
+    title: Steps followed in executing study
+    type: array
+  recruitment:
+    description: '[Text representation of ResearchStudyRecruitment] Target or actual
+      group of participants enrolled in study'
+    element_property: true
+    title: Target or actual group of participants enrolled in study
+    type: string
+  region:
+    binding_description: Countries and regions within which this artifact is targeted
+      for use.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/jurisdiction
+    binding_version: null
+    description: text representation. A country, state or other area where the study
+      is taking place rather than its precise geographic location or address.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Countries and regions within which this artifact is targeted for
+        use.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/jurisdiction
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/jurisdiction
+        term_url: http://hl7.org/fhir/ValueSet/jurisdiction
+    title: Geographic area for the study
+    type: array
+  region_coding: &id007
+    binding_description: Countries and regions within which this artifact is targeted
+      for use.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/jurisdiction
+    binding_version: null
+    description: '[system#code representation.] A country, state or other area where
+      the study is taking place rather than its precise geographic location or address.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Countries and regions within which this artifact is targeted for
+        use.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/jurisdiction
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/jurisdiction
+        term_url: http://hl7.org/fhir/ValueSet/jurisdiction
+    title: Geographic area for the study
+    type: array
+  region_text: *id007
+  relatedArtifact:
+    description: '[Text representation of RelatedArtifact] Citations, references,
+      URLs and other related documents.  When using relatedArtifact to share URLs,
+      the relatedArtifact.type will often be set to one of "documentation" or "supported-with"
+      and the URL value will often be in relatedArtifact.document.url but another
+      possible location is relatedArtifact.resource when it is a canonical URL.'
+    element_property: true
+    items:
+      type: string
+    title: References, URLs, and attachments
+    type: array
+  resourceType:
+    const: ResearchStudy
+    default: ResearchStudy
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  result:
+    backref: result_research_study
+    description: '[Text representation of Reference] Link to one or more sets of results
+      generated by the study.  Could also link to a research registry holding the
+      results such as ClinicalTrials.gov.'
+    element_property: true
+    enum_reference_types:
+    - EvidenceReport
+    - Citation
+    - DiagnosticReport
+    items:
+      type: string
+    title: Link to results generated during the study
+    type: array
+  site:
+    backref: site_research_study
+    description: '[Text representation of Reference] A facility in which study activities
+      are conducted.'
+    element_property: true
+    enum_reference_types:
+    - Location
+    - ResearchStudy
+    - Organization
+    items:
+      type: string
+    title: Facility where study activities are conducted
+    type: array
+  status:
+    binding_description: Codes that convey the current publication status of the research
+      study resource.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/publication-status
+    binding_version: 5.0.0
+    description: The publication state of the resource (not of the study).
+    element_property: true
+    element_required: true
+    enum_values:
+    - draft
+    - active
+    - retired
+    - unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: draft | active | retired | unknown
+    type: string
+  studyDesign:
+    binding_description: This is a set of terms for study design characteristics.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/study-design
+    binding_version: null
+    description: text representation. Codes categorizing the type of study such as
+      investigational vs. observational, type of blinding, type of randomization,
+      safety vs. efficacy, etc.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: This is a set of terms for study design characteristics.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/study-design
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/study-design
+        term_url: http://hl7.org/fhir/ValueSet/study-design
+    title: Classifications of the study design characteristics
+    type: array
+  studyDesign_coding: &id008
+    binding_description: This is a set of terms for study design characteristics.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/study-design
+    binding_version: null
+    description: '[system#code representation.] Codes categorizing the type of study
+      such as investigational vs. observational, type of blinding, type of randomization,
+      safety vs. efficacy, etc.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: This is a set of terms for study design characteristics.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/study-design
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/study-design
+        term_url: http://hl7.org/fhir/ValueSet/study-design
+    title: Classifications of the study design characteristics
+    type: array
+  studyDesign_text: *id008
+  title:
+    description: The human readable name of the research study.
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: Human readable name of the study
+    type: string
+  url:
+    description: Canonical identifier for this study resource, represented as a globally
+      unique URI.
+    element_property: true
+    pattern: \S*
+    title: Canonical identifier for this study resource
+    type: string
+  version:
+    description: The business version for the study record
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: The business version for the study record
+    type: string
+  whyStopped:
+    binding_description: Codes for why the study ended prematurely.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-reason-stopped
+    binding_version: null
+    description: text representation. A description and/or code explaining the premature
+      termination of the study.
+    element_property: true
+    term:
+      description: Codes for why the study ended prematurely.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-reason-stopped
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/research-study-reason-stopped
+        term_url: http://hl7.org/fhir/ValueSet/research-study-reason-stopped
+    title: accrual-goal-met | closed-due-to-toxicity | closed-due-to-lack-of-study-progress
+      | temporarily-closed-per-study-design
+    type: string
+  whyStopped_coding: &id009
+    binding_description: Codes for why the study ended prematurely.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/research-study-reason-stopped
+    binding_version: null
+    description: '[system#code representation.] A description and/or code explaining
+      the premature termination of the study.'
+    element_property: true
+    term:
+      description: Codes for why the study ended prematurely.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/research-study-reason-stopped
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/research-study-reason-stopped
+        term_url: http://hl7.org/fhir/ValueSet/research-study-reason-stopped
+    title: accrual-goal-met | closed-due-to-toxicity | closed-due-to-lack-of-study-progress
+      | temporarily-closed-per-study-design
+    type: string
+  whyStopped_text: *id009
+title: ResearchStudy
+type: object

--- a/tests/integration/data/schemas/research_subject.yaml
+++ b/tests/integration/data/schemas/research_subject.yaml
@@ -1,0 +1,181 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Administrative
+description: Participant or object which is the recipient of investigative activities
+  in a study. A ResearchSubject is a participant or object which is the recipient
+  of investigative activities in a research study. [See https://hl7.org/fhir/R5/ResearchSubject.html]
+id: research_subject
+links:
+- backref: research_subject
+  label: ResearchSubject_subject_Patient_research_subject
+  multiplicity: many_to_many
+  name: subject_Patient
+  required: false
+  target_type: patient
+- backref: research_subject
+  label: ResearchSubject_subject_Specimen_research_subject
+  multiplicity: many_to_many
+  name: subject_Specimen
+  required: false
+  target_type: specimen
+- backref: research_subject
+  label: ResearchSubject_subject_Medication_research_subject
+  multiplicity: many_to_many
+  name: subject_Medication
+  required: false
+  target_type: medication
+- backref: research_subject
+  label: ResearchSubject_subject_Substance_research_subject
+  multiplicity: many_to_many
+  name: subject_Substance
+  required: false
+  target_type: substance
+- backref: research_subject
+  label: ResearchSubject_study_ResearchStudy_research_subject
+  multiplicity: many_to_many
+  name: study
+  required: false
+  target_type: research_study
+program: '*'
+project: '*'
+properties:
+  actualComparisonGroup:
+    description: The name of the arm in the study the subject actually followed as
+      part of this study.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: What path was followed
+    type: string
+  assignedComparisonGroup:
+    description: The name of the arm in the study the subject is expected to follow
+      as part of this study.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: What path should be followed
+    type: string
+  consent:
+    backref: consent_research_subject
+    description: '[Text representation of Reference] A record of the patient''s informed
+      agreement to participate in the study.'
+    element_property: true
+    enum_reference_types:
+    - Consent
+    items:
+      type: string
+    title: Agreement to participate in study
+    type: array
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Identifiers assigned to this research subject for a study.
+    element_property: true
+    items:
+      type: string
+    title: Business Identifier for research subject in a study
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Identifiers assigned
+      to this research subject for a study.'
+    element_property: true
+    items:
+      type: string
+    title: Business Identifier for research subject in a study
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Identifiers assigned
+      to this research subject for a study.'
+    element_property: true
+    items:
+      type: string
+    title: Business Identifier for research subject in a study
+    type: array
+  period:
+    description: '[Text representation of Period] The dates the subject began and
+      ended their participation in the study.'
+    element_property: true
+    title: Start and end of participation
+    type: string
+  progress:
+    description: '[Text representation of ResearchSubjectProgress] The current state
+      (status) of the subject and resons for status change where appropriate.'
+    element_property: true
+    items:
+      type: string
+    title: Subject status
+    type: array
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  resourceType:
+    const: ResearchSubject
+    default: ResearchSubject
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  status:
+    binding_description: Codes that convey the current publication status of the research
+      study resource.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/publication-status
+    binding_version: 5.0.0
+    description: The publication state of the resource (not of the subject).
+    element_property: true
+    element_required: true
+    enum_values:
+    - draft
+    - active
+    - retired
+    - unknown
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: draft | active | retired | unknown
+    type: string
+  study:
+    backref: research_subject
+    description: '[Text representation of Reference] Reference to the study the subject
+      is participating in.'
+    element_property: true
+    enum_reference_types:
+    - ResearchStudy
+    title: Study subject is part of
+    type: string
+  subject:
+    backref: research_subject
+    description: '[Text representation of Reference] The record of the person, animal
+      or other entity involved in the study.'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Group
+    - Specimen
+    - Device
+    - Medication
+    - Substance
+    - BiologicallyDerivedProduct
+    title: Who or what is part of study
+    type: string
+title: ResearchSubject
+type: object

--- a/tests/integration/data/schemas/simplified-fhir.json
+++ b/tests/integration/data/schemas/simplified-fhir.json
@@ -1,0 +1,13797 @@
+{
+  "_core_metadata_collection.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
+    "category": "administrative",
+    "description": "A collection of data files in a project.  DEPRECATED - included for portal compatibility",
+    "id": "core_metadata_collection",
+    "links": [
+      {
+        "backref": "core_metadata_collections",
+        "label": "data_from",
+        "multiplicity": "many_to_one",
+        "name": "projects",
+        "required": true,
+        "target_type": "project"
+      }
+    ],
+    "namespace": "https://data.midrc.org",
+    "nodeTerms": null,
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "$ref": "_definitions.yaml#/ubiquitous_properties",
+      "contributor": {
+        "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+        "type": "string"
+      },
+      "coverage": {
+        "description": "The spatial or temporal topic of the resource, the spatial applicability of the resource, or the jurisdiction under which the resource is relevant. Spatial topic and spatial applicability may be a named place or a location specified by its geographic coordinates. Temporal topic may be a named period, date, or date range. A jurisdiction may be a named administrative entity or a geographic place to which the resource applies. Recommended best practice is to use a controlled vocabulary such as the Thesaurus of Geographic Names [TGN] (http-//www.getty.edu/research/tools/vocabulary/tgn/index.html). Where appropriate, named places or time periods can be used in preference to numeric identifiers such as sets of coordinates or date ranges.",
+        "type": "string"
+      },
+      "creator": {
+        "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+        "type": "string"
+      },
+      "data_type": {
+        "description": "The nature or genre of the resource. Recommended best practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical medium, or dimensions of the resource, use the Format element.",
+        "type": "string"
+      },
+      "date": {
+        "description": "The date the collection of data was created.",
+        "type": "string"
+      },
+      "description": {
+        "description": "An account of the resource. Description may include but is not limited to- an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+        "type": "string"
+      },
+      "format": {
+        "description": "The file format, physical medium, or dimensions of the resource. Examples of dimensions include size and duration. Recommended best practice is to use a controlled vocabulary such as the list of Internet Media Types [MIME] (http-//www.iana.org/assignments/media-types/).",
+        "type": "string"
+      },
+      "language": {
+        "description": "A language of the resource. Recommended best practice is to use a controlled vocabulary such as RFC 4646 (http-//www.ietf.org/rfc/rfc4646.txt).",
+        "type": "string"
+      },
+      "projects": {
+        "$ref": "_definitions.yaml#/to_one_project",
+        "description": "The project code for the record in the project node that this core_metadata_collection belongs to, i.e., a link to the parent node."
+      },
+      "publisher": {
+        "description": "An entity responsible for making the resource available. Examples of a Publisher include a person, an organization, or a service. Typically, the name of a Publisher should be used to indicate the entity.",
+        "type": "string"
+      },
+      "relation": {
+        "description": "A related resource. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system.",
+        "type": "string"
+      },
+      "rights": {
+        "description": "Information about rights held in and over the resource. Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights.",
+        "type": "string"
+      },
+      "source": {
+        "description": "A related resource from which the described resource is derived. The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system.",
+        "type": "string"
+      },
+      "subject": {
+        "description": "The topic of the resource. Typically, the subject will be represented using keywords, key phrases, or classification codes. Recommended best practice is to use a controlled vocabulary.",
+        "type": "string"
+      },
+      "title": {
+        "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "submitter_id",
+      "type",
+      "projects"
+    ],
+    "submittable": true,
+    "systemProperties": [
+      "id",
+      "project_id",
+      "state",
+      "created_datetime",
+      "updated_datetime"
+    ],
+    "title": "Core Metadata Collection",
+    "type": "object",
+    "uniqueKeys": [
+      [
+        "id"
+      ],
+      [
+        "project_id",
+        "submitter_id"
+      ]
+    ],
+    "validators": null
+  },
+  "practitioner_role.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Administrative",
+    "description": "Roles/organizations the practitioner is associated with. A specific set of Roles/Locations/specialties/services that a practitioner may perform at an organization for a period of time. [See https://hl7.org/fhir/R5/PractitionerRole.html]",
+    "id": "practitioner_role",
+    "links": [
+      {
+        "backref": "location_practitioner_role",
+        "label": "PractitionerRole_location_Location_location_practitioner_role",
+        "multiplicity": "many_to_many",
+        "name": "location",
+        "required": false,
+        "target_type": "location"
+      },
+      {
+        "backref": "practitioner_role",
+        "label": "PractitionerRole_organization_Organization_practitioner_role",
+        "multiplicity": "many_to_many",
+        "name": "organization",
+        "required": false,
+        "target_type": "organization"
+      },
+      {
+        "backref": "practitioner_role",
+        "label": "PractitionerRole_practitioner_Practitioner_practitioner_role",
+        "multiplicity": "many_to_many",
+        "name": "practitioner",
+        "required": false,
+        "target_type": "practitioner"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "active": {
+        "description": " Whether this practitioner role record is in active use. Some systems may use this property to mark non-active practitioners, such as those that are not currently employed.",
+        "element_property": true,
+        "title": "Whether this practitioner role record is in active use",
+        "type": "boolean"
+      },
+      "availability": {
+        "description": "[Text representation of Availability] A collection of times the practitioner is available or performing this role at the location and/or healthcareservice.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Times the Practitioner is available at this location and/or healthcare service (including exceptions)",
+        "type": "array"
+      },
+      "characteristic": {
+        "binding_description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibility).",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/service-mode",
+        "binding_version": null,
+        "description": "text representation. Collection of characteristics (attributes)",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibility).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/service-mode",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/service-mode",
+            "term_url": "http://hl7.org/fhir/ValueSet/service-mode"
+          }
+        },
+        "title": "Collection of characteristics (attributes)",
+        "type": "array"
+      },
+      "characteristic_coding": {
+        "binding_description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibility).",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/service-mode",
+        "binding_version": null,
+        "description": "[system#code representation.] Collection of characteristics (attributes)",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibility).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/service-mode",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/service-mode",
+            "term_url": "http://hl7.org/fhir/ValueSet/service-mode"
+          }
+        },
+        "title": "Collection of characteristics (attributes)",
+        "type": "array"
+      },
+      "characteristic_text": {
+        "binding_description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibility).",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/service-mode",
+        "binding_version": null,
+        "description": "[system#code representation.] Collection of characteristics (attributes)",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibility).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/service-mode",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/service-mode",
+            "term_url": "http://hl7.org/fhir/ValueSet/service-mode"
+          }
+        },
+        "title": "Collection of characteristics (attributes)",
+        "type": "array"
+      },
+      "code": {
+        "binding_description": "The role a person plays representing an organization.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/practitioner-role",
+        "binding_version": null,
+        "description": "text representation. Roles which this practitioner is authorized to perform for the organization.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "The role a person plays representing an organization.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/practitioner-role",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/practitioner-role",
+            "term_url": "http://hl7.org/fhir/ValueSet/practitioner-role"
+          }
+        },
+        "title": "Roles which this practitioner may perform",
+        "type": "array"
+      },
+      "code_coding": {
+        "binding_description": "The role a person plays representing an organization.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/practitioner-role",
+        "binding_version": null,
+        "description": "[system#code representation.] Roles which this practitioner is authorized to perform for the organization.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "The role a person plays representing an organization.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/practitioner-role",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/practitioner-role",
+            "term_url": "http://hl7.org/fhir/ValueSet/practitioner-role"
+          }
+        },
+        "title": "Roles which this practitioner may perform",
+        "type": "array"
+      },
+      "code_text": {
+        "binding_description": "The role a person plays representing an organization.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/practitioner-role",
+        "binding_version": null,
+        "description": "[system#code representation.] Roles which this practitioner is authorized to perform for the organization.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "The role a person plays representing an organization.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/practitioner-role",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/practitioner-role",
+            "term_url": "http://hl7.org/fhir/ValueSet/practitioner-role"
+          }
+        },
+        "title": "Roles which this practitioner may perform",
+        "type": "array"
+      },
+      "communication": {
+        "binding_description": "IETF language tag for a human language",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/all-languages",
+        "binding_version": "5.0.0",
+        "description": "text representation. A language the practitioner can use in patient communication. The practitioner may know several languages (listed in practitioner.communication), however these are the languages that could be advertised in a directory for a patient to search.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "IETF language tag for a human language",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/all-languages",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/all-languages",
+            "term_url": "http://hl7.org/fhir/ValueSet/all-languages"
+          }
+        },
+        "title": "A language the practitioner (in this role) can use in patient communication",
+        "type": "array"
+      },
+      "communication_coding": {
+        "binding_description": "IETF language tag for a human language",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/all-languages",
+        "binding_version": "5.0.0",
+        "description": "[system#code representation.] A language the practitioner can use in patient communication. The practitioner may know several languages (listed in practitioner.communication), however these are the languages that could be advertised in a directory for a patient to search.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "IETF language tag for a human language",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/all-languages",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/all-languages",
+            "term_url": "http://hl7.org/fhir/ValueSet/all-languages"
+          }
+        },
+        "title": "A language the practitioner (in this role) can use in patient communication",
+        "type": "array"
+      },
+      "communication_text": {
+        "binding_description": "IETF language tag for a human language",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/all-languages",
+        "binding_version": "5.0.0",
+        "description": "[system#code representation.] A language the practitioner can use in patient communication. The practitioner may know several languages (listed in practitioner.communication), however these are the languages that could be advertised in a directory for a patient to search.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "IETF language tag for a human language",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/all-languages",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/all-languages",
+            "term_url": "http://hl7.org/fhir/ValueSet/all-languages"
+          }
+        },
+        "title": "A language the practitioner (in this role) can use in patient communication",
+        "type": "array"
+      },
+      "contact": {
+        "description": "[Text representation of ExtendedContactDetail] The contact details of communication devices available relevant to the specific PractitionerRole. This can include addresses, phone numbers, fax numbers, mobile numbers, email addresses and web sites.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Official contact details relating to this PractitionerRole",
+        "type": "array"
+      },
+      "endpoint": {
+        "backref": "endpoint_practitioner_role",
+        "description": "[Text representation of Reference]  Technical endpoints providing access to services operated for the practitioner with this role. Commonly used for locating scheduling services, or identifying where to send referrals electronically.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Endpoint"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Endpoints for interacting with the practitioner in this role",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "healthcareService": {
+        "backref": "healthcareService_practitioner_role",
+        "description": "[Text representation of Reference] The list of healthcare services that this worker provides for this role's Organization/Location(s).",
+        "element_property": true,
+        "enum_reference_types": [
+          "HealthcareService"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Healthcare services provided for this role's Organization/Location(s)",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Business Identifiers that are specific to a role/location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Identifiers for a role/location",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Business Identifiers that are specific to a role/location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Identifiers for a role/location",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Business Identifiers that are specific to a role/location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Identifiers for a role/location",
+        "type": "array"
+      },
+      "location": {
+        "backref": "location_practitioner_role",
+        "description": "[Text representation of Reference] The location(s) at which this practitioner provides care.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Location"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Location(s) where the practitioner provides care",
+        "type": "array"
+      },
+      "organization": {
+        "backref": "practitioner_role",
+        "description": "[Text representation of Reference] The organization where the Practitioner performs the roles associated.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "Organization where the roles are available",
+        "type": "string"
+      },
+      "period": {
+        "description": "[Text representation of Period] The period during which the person is authorized to act as a practitioner in these role(s) for the organization.",
+        "element_property": true,
+        "title": "The period during which the practitioner is authorized to perform in these role(s)",
+        "type": "string"
+      },
+      "practitioner": {
+        "backref": "practitioner_role",
+        "description": "[Text representation of Reference] Practitioner that is able to provide the defined services for the organization.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Practitioner"
+        ],
+        "title": "Practitioner that provides services for the organization",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "PractitionerRole",
+        "default": "PractitionerRole",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "specialty": {
+        "binding_description": "Specific specialty associated with the agency.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+        "binding_version": null,
+        "description": "text representation. The specialty of a practitioner that describes the functional role they are practicing at a given organization or location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Specific specialty associated with the agency.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
+          }
+        },
+        "title": "Specific specialty of the practitioner",
+        "type": "array"
+      },
+      "specialty_coding": {
+        "binding_description": "Specific specialty associated with the agency.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] The specialty of a practitioner that describes the functional role they are practicing at a given organization or location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Specific specialty associated with the agency.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
+          }
+        },
+        "title": "Specific specialty of the practitioner",
+        "type": "array"
+      },
+      "specialty_text": {
+        "binding_description": "Specific specialty associated with the agency.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] The specialty of a practitioner that describes the functional role they are practicing at a given organization or location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Specific specialty associated with the agency.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
+          }
+        },
+        "title": "Specific specialty of the practitioner",
+        "type": "array"
+      }
+    },
+    "title": "PractitionerRole",
+    "type": "object"
+  },
+  "observation.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "Measurements and simple assertions. Measurements and simple assertions made about a patient, device or other subject. [See https://hl7.org/fhir/R5/Observation.html]",
+    "id": "observation",
+    "links": [
+      {
+        "backref": "subject_observation",
+        "label": "Observation_subject_Patient_subject_observation",
+        "multiplicity": "many_to_many",
+        "name": "subject_Patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "focus_observation",
+        "label": "Observation_focus_ResearchStudy_focus_observation",
+        "multiplicity": "many_to_many",
+        "name": "focus",
+        "required": false,
+        "target_type": "research_study"
+      },
+      {
+        "backref": "specimen_observation",
+        "label": "Observation_specimen_Specimen_specimen_observation",
+        "multiplicity": "many_to_many",
+        "name": "specimen_Specimen",
+        "required": false,
+        "target_type": "specimen"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "basedOn": {
+        "backref": "basedOn_observation",
+        "description": "[Text representation of Reference] A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+        "element_property": true,
+        "enum_reference_types": [
+          "CarePlan",
+          "DeviceRequest",
+          "ImmunizationRecommendation",
+          "MedicationRequest",
+          "NutritionOrder",
+          "ServiceRequest"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Fulfills plan, proposal or order",
+        "type": "array"
+      },
+      "bodySite": {
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "text representation. Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+        "element_property": true,
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Observed body part",
+        "type": "string"
+      },
+      "bodySite_coding": {
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+        "element_property": true,
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Observed body part",
+        "type": "string"
+      },
+      "bodySite_text": {
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+        "element_property": true,
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Observed body part",
+        "type": "string"
+      },
+      "bodyStructure": {
+        "backref": "observation",
+        "description": "[Text representation of Reference] Indicates the body structure on the subject's body where the observation was made (i.e. the target site).",
+        "element_property": true,
+        "enum_reference_types": [
+          "BodyStructure"
+        ],
+        "title": "Observed body structure",
+        "type": "string"
+      },
+      "category": {
+        "binding_description": "Codes for high level observation categories.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-category",
+        "binding_version": null,
+        "description": "text representation. A code that classifies the general type of observation being made.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes for high level observation categories.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/observation-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/observation-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/observation-category"
+          }
+        },
+        "title": "Classification of  type of observation",
+        "type": "array"
+      },
+      "category_coding": {
+        "binding_description": "Codes for high level observation categories.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A code that classifies the general type of observation being made.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes for high level observation categories.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/observation-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/observation-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/observation-category"
+          }
+        },
+        "title": "Classification of  type of observation",
+        "type": "array"
+      },
+      "category_text": {
+        "binding_description": "Codes for high level observation categories.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A code that classifies the general type of observation being made.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes for high level observation categories.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/observation-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/observation-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/observation-category"
+          }
+        },
+        "title": "Classification of  type of observation",
+        "type": "array"
+      },
+      "code": {
+        "binding_description": "LDL Cholesterol codes - measured or calculated.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes",
+        "binding_version": null,
+        "description": "text representation. Describes what was observed. Sometimes this is called the observation \"name\".",
+        "element_property": true,
+        "term": {
+          "description": "LDL Cholesterol codes - measured or calculated.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes"
+          }
+        },
+        "title": "Type of observation (code / type)",
+        "type": "string"
+      },
+      "code_coding": {
+        "binding_description": "LDL Cholesterol codes - measured or calculated.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes what was observed. Sometimes this is called the observation \"name\".",
+        "element_property": true,
+        "term": {
+          "description": "LDL Cholesterol codes - measured or calculated.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes"
+          }
+        },
+        "title": "Type of observation (code / type)",
+        "type": "string"
+      },
+      "code_text": {
+        "binding_description": "LDL Cholesterol codes - measured or calculated.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes what was observed. Sometimes this is called the observation \"name\".",
+        "element_property": true,
+        "term": {
+          "description": "LDL Cholesterol codes - measured or calculated.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/lipid-ldl-codes"
+          }
+        },
+        "title": "Type of observation (code / type)",
+        "type": "string"
+      },
+      "component": {
+        "description": "[Text representation of ObservationComponent] Some observations have multiple component observations.  These component observations are expressed as separate code value pairs that share the same attributes.  Examples include systolic and diastolic component observations for blood pressure measurement and multiple component observations for genetics observations.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Component results",
+        "type": "array"
+      },
+      "dataAbsentReason": {
+        "binding_description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+        "binding_version": null,
+        "description": "text representation. Provides a reason why the expected value in the element Observation.value[x] is missing.",
+        "element_property": true,
+        "term": {
+          "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+          }
+        },
+        "title": "Why the result is missing",
+        "type": "string"
+      },
+      "dataAbsentReason_coding": {
+        "binding_description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Provides a reason why the expected value in the element Observation.value[x] is missing.",
+        "element_property": true,
+        "term": {
+          "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+          }
+        },
+        "title": "Why the result is missing",
+        "type": "string"
+      },
+      "dataAbsentReason_text": {
+        "binding_description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Provides a reason why the expected value in the element Observation.value[x] is missing.",
+        "element_property": true,
+        "term": {
+          "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/data-absent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+          }
+        },
+        "title": "Why the result is missing",
+        "type": "string"
+      },
+      "derivedFrom": {
+        "backref": "derivedFrom_observation",
+        "description": "[Text representation of Reference] The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+        "element_property": true,
+        "enum_reference_types": [
+          "DocumentReference",
+          "ImagingStudy",
+          "ImagingSelection",
+          "QuestionnaireResponse",
+          "Observation",
+          "MolecularSequence",
+          "GenomicStudy"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Related resource from which the observation is made",
+        "type": "array"
+      },
+      "device": {
+        "backref": "device_observation",
+        "description": "[Text representation of Reference] A reference to the device that generates the measurements or the device settings for the device",
+        "element_property": true,
+        "enum_reference_types": [
+          "Device",
+          "DeviceMetric"
+        ],
+        "title": "A reference to the device that generates the measurements or the device settings for the device",
+        "type": "string"
+      },
+      "effectiveDateTime": {
+        "description": "The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "effective",
+        "one_of_many_required": false,
+        "title": "Clinically relevant time/time-period for observation",
+        "type": "string"
+      },
+      "effectiveInstant": {
+        "description": "The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "effective",
+        "one_of_many_required": false,
+        "title": "Clinically relevant time/time-period for observation",
+        "type": "string"
+      },
+      "effectivePeriod": {
+        "description": "[Text representation of Period] The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
+        "element_property": true,
+        "one_of_many": "effective",
+        "one_of_many_required": false,
+        "title": "Clinically relevant time/time-period for observation",
+        "type": "string"
+      },
+      "effectiveTiming": {
+        "description": "[Text representation of Timing] The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
+        "element_property": true,
+        "one_of_many": "effective",
+        "one_of_many_required": false,
+        "title": "Clinically relevant time/time-period for observation",
+        "type": "string"
+      },
+      "encounter": {
+        "backref": "observation",
+        "description": "[Text representation of Reference] The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Encounter"
+        ],
+        "title": "Healthcare event during which this observation is made",
+        "type": "string"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "focus": {
+        "backref": "focus_observation",
+        "description": "[Text representation of Reference] The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor.",
+        "element_property": true,
+        "enum_reference_types": [
+          "ResearchStudy"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "What the observation is about, when it is not about the subject of record",
+        "type": "array"
+      },
+      "hasMember": {
+        "backref": "hasMember_observation",
+        "description": "[Text representation of Reference] This observation is a group observation (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes the target as a member of the group.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Observation",
+          "QuestionnaireResponse",
+          "MolecularSequence"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Related resource that belongs to the Observation group",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "A unique identifier assigned to this observation.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business Identifier for observation",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] A unique identifier assigned to this observation.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business Identifier for observation",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] A unique identifier assigned to this observation.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business Identifier for observation",
+        "type": "array"
+      },
+      "instantiatesCanonical": {
+        "description": "The reference to a FHIR ObservationDefinition resource that provides the definition that is adhered to in whole or in part by this Observation instance.",
+        "element_property": true,
+        "enum_reference_types": [
+          "ObservationDefinition"
+        ],
+        "one_of_many": "instantiates",
+        "one_of_many_required": false,
+        "pattern": "\\S*",
+        "title": "Instantiates FHIR ObservationDefinition",
+        "type": "string"
+      },
+      "instantiatesReference": {
+        "backref": "observation",
+        "description": "[Text representation of Reference] The reference to a FHIR ObservationDefinition resource that provides the definition that is adhered to in whole or in part by this Observation instance.",
+        "element_property": true,
+        "enum_reference_types": [
+          "ObservationDefinition"
+        ],
+        "one_of_many": "instantiates",
+        "one_of_many_required": false,
+        "title": "Instantiates FHIR ObservationDefinition",
+        "type": "string"
+      },
+      "interpretation": {
+        "binding_description": "Codes identifying interpretations of observations.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+        "binding_version": null,
+        "description": "text representation. A categorical assessment of an observation value.  For example, high, low, normal.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes identifying interpretations of observations.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+            "term_url": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+          }
+        },
+        "title": "High, low, normal, etc",
+        "type": "array"
+      },
+      "interpretation_coding": {
+        "binding_description": "Codes identifying interpretations of observations.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+        "binding_version": null,
+        "description": "[system#code representation.] A categorical assessment of an observation value.  For example, high, low, normal.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes identifying interpretations of observations.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+            "term_url": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+          }
+        },
+        "title": "High, low, normal, etc",
+        "type": "array"
+      },
+      "interpretation_text": {
+        "binding_description": "Codes identifying interpretations of observations.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+        "binding_version": null,
+        "description": "[system#code representation.] A categorical assessment of an observation value.  For example, high, low, normal.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes identifying interpretations of observations.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+            "term_url": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+          }
+        },
+        "title": "High, low, normal, etc",
+        "type": "array"
+      },
+      "issued": {
+        "description": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "Date/Time this version was made available",
+        "type": "string"
+      },
+      "method": {
+        "binding_description": "Methods for simple observations.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-methods",
+        "binding_version": null,
+        "description": "text representation. Indicates the mechanism used to perform the observation.",
+        "element_property": true,
+        "term": {
+          "description": "Methods for simple observations.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/observation-methods",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/observation-methods",
+            "term_url": "http://hl7.org/fhir/ValueSet/observation-methods"
+          }
+        },
+        "title": "How it was done",
+        "type": "string"
+      },
+      "method_coding": {
+        "binding_description": "Methods for simple observations.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-methods",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the mechanism used to perform the observation.",
+        "element_property": true,
+        "term": {
+          "description": "Methods for simple observations.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/observation-methods",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/observation-methods",
+            "term_url": "http://hl7.org/fhir/ValueSet/observation-methods"
+          }
+        },
+        "title": "How it was done",
+        "type": "string"
+      },
+      "method_text": {
+        "binding_description": "Methods for simple observations.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-methods",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the mechanism used to perform the observation.",
+        "element_property": true,
+        "term": {
+          "description": "Methods for simple observations.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/observation-methods",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/observation-methods",
+            "term_url": "http://hl7.org/fhir/ValueSet/observation-methods"
+          }
+        },
+        "title": "How it was done",
+        "type": "string"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] Comments about the observation or the results.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Comments about the observation",
+        "type": "array"
+      },
+      "partOf": {
+        "backref": "partOf_observation",
+        "description": "[Text representation of Reference] A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "MedicationAdministration",
+          "MedicationDispense",
+          "MedicationStatement",
+          "Procedure",
+          "Immunization",
+          "ImagingStudy",
+          "GenomicStudy"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Part of referenced event",
+        "type": "array"
+      },
+      "performer": {
+        "backref": "performer_observation",
+        "description": "[Text representation of Reference] Who was responsible for asserting the observed value as \"true\".",
+        "element_property": true,
+        "enum_reference_types": [
+          "Practitioner",
+          "PractitionerRole",
+          "Organization",
+          "CareTeam",
+          "Patient",
+          "RelatedPerson"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Who is responsible for the observation",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "referenceRange": {
+        "description": "[Text representation of ObservationReferenceRange] Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Provides guide for interpretation",
+        "type": "array"
+      },
+      "resourceType": {
+        "const": "Observation",
+        "default": "Observation",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "specimen": {
+        "backref": "specimen_observation",
+        "description": "[Text representation of Reference] The specimen that was used when this observation was made.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Specimen",
+          "Group"
+        ],
+        "title": "Specimen used for this observation",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "Codes providing the status of an observation.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/observation-status",
+        "binding_version": "5.0.0",
+        "description": "The status of the result value.",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "registered",
+          "preliminary",
+          "final",
+          "amended",
+          "+"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "registered | preliminary | final | amended +",
+        "type": "string"
+      },
+      "subject": {
+        "backref": "subject_observation",
+        "description": "[Text representation of Reference] The patient, or group of patients, location, device, organization, procedure or practitioner this observation is about and into whose or what record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Group",
+          "Device",
+          "Location",
+          "Organization",
+          "Procedure",
+          "Practitioner",
+          "Medication",
+          "Substance",
+          "BiologicallyDerivedProduct",
+          "NutritionProduct"
+        ],
+        "title": "Who and/or what the observation is about",
+        "type": "string"
+      },
+      "triggeredBy": {
+        "description": "[Text representation of ObservationTriggeredBy] Identifies the observation(s) that triggered the performance of this observation.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Triggering observation(s)",
+        "type": "array"
+      },
+      "valueAttachment": {
+        "description": "[Text representation of Attachment] The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueBoolean": {
+        "description": "The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "boolean"
+      },
+      "valueCodeableConcept": {
+        "description": "text representation. The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueCodeableConcept_coding": {
+        "description": "[system#code representation.] The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueCodeableConcept_text": {
+        "description": "[system#code representation.] The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueDateTime": {
+        "description": "The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueInteger": {
+        "description": "The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "integer"
+      },
+      "valuePeriod": {
+        "description": "[Text representation of Period] The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueQuantity": {
+        "description": "[Text representation of Quantity] text representation. The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueQuantity_unit": {
+        "title": "Unit representation. Actual result",
+        "type": "string"
+      },
+      "valueQuantity_value": {
+        "title": "Numerical value (with implicit precision) representation. Actual result",
+        "type": "number"
+      },
+      "valueRange": {
+        "description": "[Text representation of Range] The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueRatio": {
+        "description": "[Text representation of Ratio] The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueReference": {
+        "backref": "valueReference_observation",
+        "description": "[Text representation of Reference] The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "enum_reference_types": [
+          "MolecularSequence"
+        ],
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueSampledData": {
+        "description": "[Text representation of SampledData] The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueString": {
+        "description": "The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Actual result",
+        "type": "string"
+      },
+      "valueTime": {
+        "description": "The information determined as a result of making the observation, if the information has a simple value.",
+        "element_property": true,
+        "format": "time",
+        "one_of_many": "value",
+        "one_of_many_required": false,
+        "title": "Actual result",
+        "type": "string"
+      }
+    },
+    "title": "Observation",
+    "type": "object"
+  },
+  "research_study.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Administrative",
+    "description": "Investigation to increase healthcare-related patient-independent knowledge. A scientific study of nature that sometimes includes processes involved in health and disease. For example, clinical trials are research studies that involve people. These studies may be related to new ways to screen, prevent, diagnose, and treat disease. They may also study certain outcomes and certain groups of people by looking at data collected in the past or future. [See https://hl7.org/fhir/R5/ResearchStudy.html]",
+    "id": "research_study",
+    "links": [
+      {
+        "backref": "focus_research_study",
+        "label": "ResearchStudy_focus_Medication_focus_research_study",
+        "multiplicity": "many_to_many",
+        "name": "focus_Medication",
+        "required": false,
+        "target_type": "medication"
+      },
+      {
+        "backref": "partOf_research_study",
+        "label": "ResearchStudy_partOf_ResearchStudy_partOf_research_study",
+        "multiplicity": "many_to_many",
+        "name": "partOf",
+        "required": false,
+        "target_type": "research_study"
+      },
+      {
+        "backref": "result_research_study",
+        "label": "ResearchStudy_result_DiagnosticReport_result_research_study",
+        "multiplicity": "many_to_many",
+        "name": "result_DiagnosticReport",
+        "required": false,
+        "target_type": "diagnostic_report"
+      },
+      {
+        "backref": "site_research_study",
+        "label": "ResearchStudy_site_Location_site_research_study",
+        "multiplicity": "many_to_many",
+        "name": "site_Location",
+        "required": false,
+        "target_type": "location"
+      },
+      {
+        "backref": "site_research_study",
+        "label": "ResearchStudy_site_Organization_site_research_study",
+        "multiplicity": "many_to_many",
+        "name": "site_Organization",
+        "required": false,
+        "target_type": "organization"
+      },
+      {
+        "backref": "research_study",
+        "label": "ResearchStudy_gen3_project_Project_research_study",
+        "multiplicity": "many_to_many",
+        "name": "gen3_project",
+        "required": false,
+        "target_type": "project"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "associatedParty": {
+        "description": "[Text representation of ResearchStudyAssociatedParty] Sponsors, collaborators, and other parties",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Sponsors, collaborators, and other parties",
+        "type": "array"
+      },
+      "classifier": {
+        "binding_description": "desc.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-classifiers",
+        "binding_version": null,
+        "description": "text representation. Additional grouping mechanism or categorization of a research study. Example: FDA regulated device, FDA regulated drug, MPG Paragraph 23b (a German legal requirement), IRB-exempt, etc. Implementation Note: do not use the classifier element to support existing semantics that are already supported thru explicit elements in the resource.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "desc.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-classifiers",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-classifiers",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-classifiers"
+          }
+        },
+        "title": "Classification for the study",
+        "type": "array"
+      },
+      "classifier_coding": {
+        "binding_description": "desc.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-classifiers",
+        "binding_version": null,
+        "description": "[system#code representation.] Additional grouping mechanism or categorization of a research study. Example: FDA regulated device, FDA regulated drug, MPG Paragraph 23b (a German legal requirement), IRB-exempt, etc. Implementation Note: do not use the classifier element to support existing semantics that are already supported thru explicit elements in the resource.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "desc.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-classifiers",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-classifiers",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-classifiers"
+          }
+        },
+        "title": "Classification for the study",
+        "type": "array"
+      },
+      "classifier_text": {
+        "binding_description": "desc.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-classifiers",
+        "binding_version": null,
+        "description": "[system#code representation.] Additional grouping mechanism or categorization of a research study. Example: FDA regulated device, FDA regulated drug, MPG Paragraph 23b (a German legal requirement), IRB-exempt, etc. Implementation Note: do not use the classifier element to support existing semantics that are already supported thru explicit elements in the resource.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "desc.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-classifiers",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-classifiers",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-classifiers"
+          }
+        },
+        "title": "Classification for the study",
+        "type": "array"
+      },
+      "comparisonGroup": {
+        "description": "[Text representation of ResearchStudyComparisonGroup] Describes an expected event or sequence of events for one of the subjects of a study. E.g. for a living subject: exposure to drug A, wash-out, exposure to drug B, wash-out, follow-up. E.g. for a stability study: {store sample from lot A at 25 degrees for 1 month}, {store sample from lot A at 40 degrees for 1 month}.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Defined path through the study for a subject",
+        "type": "array"
+      },
+      "condition": {
+        "binding_description": "Identification of the condition or diagnosis.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-code",
+        "binding_version": null,
+        "description": "text representation. The condition that is the focus of the study.  For example, In a study to examine risk factors for Lupus, might have as an inclusion criterion \"healthy volunteer\", but the target condition code would be a Lupus SNOMED code.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Identification of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/condition-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-code"
+          }
+        },
+        "title": "Condition being studied",
+        "type": "array"
+      },
+      "condition_coding": {
+        "binding_description": "Identification of the condition or diagnosis.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-code",
+        "binding_version": null,
+        "description": "[system#code representation.] The condition that is the focus of the study.  For example, In a study to examine risk factors for Lupus, might have as an inclusion criterion \"healthy volunteer\", but the target condition code would be a Lupus SNOMED code.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Identification of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/condition-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-code"
+          }
+        },
+        "title": "Condition being studied",
+        "type": "array"
+      },
+      "condition_text": {
+        "binding_description": "Identification of the condition or diagnosis.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-code",
+        "binding_version": null,
+        "description": "[system#code representation.] The condition that is the focus of the study.  For example, In a study to examine risk factors for Lupus, might have as an inclusion criterion \"healthy volunteer\", but the target condition code would be a Lupus SNOMED code.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Identification of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/condition-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-code"
+          }
+        },
+        "title": "Condition being studied",
+        "type": "array"
+      },
+      "date": {
+        "description": "The date (and optionally time) when the ResearchStudy Resource was last significantly changed. The date must change when the business version changes and it must change if the status code changes. In addition, it should change when the substantive content of the ResearchStudy Resource changes.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "Date the resource last changed",
+        "type": "string"
+      },
+      "description": {
+        "description": "A detailed and human-readable narrative of the study. E.g., study abstract.",
+        "element_property": true,
+        "pattern": "\\s*(\\S|\\s)*",
+        "title": "Detailed narrative of the study",
+        "type": "string"
+      },
+      "descriptionSummary": {
+        "description": "A brief text for explaining the study.",
+        "element_property": true,
+        "pattern": "\\s*(\\S|\\s)*",
+        "title": "Brief text explaining the study",
+        "type": "string"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "focus": {
+        "backref": "focus_research_study",
+        "binding_description": "Common codes of research study focus",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-focus-type",
+        "binding_version": null,
+        "description": "text representation. The medication(s), food(s), therapy(ies), device(s) or other concerns or interventions that the study is seeking to gain more information about.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Medication",
+          "MedicinalProductDefinition",
+          "SubstanceDefinition",
+          "EvidenceVariable"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Common codes of research study focus",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-focus-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-focus-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-focus-type"
+          }
+        },
+        "title": "Drugs, devices, etc. under study",
+        "type": "array"
+      },
+      "focus_coding": {
+        "backref": "focus_research_study",
+        "binding_description": "Common codes of research study focus",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-focus-type",
+        "binding_version": null,
+        "description": "[system#code representation.] The medication(s), food(s), therapy(ies), device(s) or other concerns or interventions that the study is seeking to gain more information about.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Medication",
+          "MedicinalProductDefinition",
+          "SubstanceDefinition",
+          "EvidenceVariable"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Common codes of research study focus",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-focus-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-focus-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-focus-type"
+          }
+        },
+        "title": "Drugs, devices, etc. under study",
+        "type": "array"
+      },
+      "focus_text": {
+        "backref": "focus_research_study",
+        "binding_description": "Common codes of research study focus",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-focus-type",
+        "binding_version": null,
+        "description": "[system#code representation.] The medication(s), food(s), therapy(ies), device(s) or other concerns or interventions that the study is seeking to gain more information about.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Medication",
+          "MedicinalProductDefinition",
+          "SubstanceDefinition",
+          "EvidenceVariable"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Common codes of research study focus",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-focus-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-focus-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-focus-type"
+          }
+        },
+        "title": "Drugs, devices, etc. under study",
+        "type": "array"
+      },
+      "gen3_project": {
+        "backref": "research_study",
+        "description": "[Text representation of Reference] The Gen3 project this study belongs to.  Used to generate link.",
+        "enum_reference_types": [
+          "Project"
+        ],
+        "title": "The Gen3 project this study belongs to.",
+        "type": "string"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Identifiers assigned to this research study by the sponsor or other systems.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business Identifier for study",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Identifiers assigned to this research study by the sponsor or other systems.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business Identifier for study",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Identifiers assigned to this research study by the sponsor or other systems.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business Identifier for study",
+        "type": "array"
+      },
+      "keyword": {
+        "description": "text representation. Key terms to aid in searching for or filtering the study.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Used to search for the study",
+        "type": "array"
+      },
+      "keyword_coding": {
+        "description": "[system#code representation.] Key terms to aid in searching for or filtering the study.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Used to search for the study",
+        "type": "array"
+      },
+      "keyword_text": {
+        "description": "[system#code representation.] Key terms to aid in searching for or filtering the study.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Used to search for the study",
+        "type": "array"
+      },
+      "label_": {
+        "description": "[Text representation of ResearchStudyLabel] Additional names for the study",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional names for the study",
+        "type": "array"
+      },
+      "name": {
+        "description": "Name for this study (computer friendly)",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Name for this study (computer friendly)",
+        "type": "string"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] Comments made about the study by the performer, subject or other participants.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Comments made about the study",
+        "type": "array"
+      },
+      "objective": {
+        "description": "[Text representation of ResearchStudyObjective] A goal that the study is aiming to achieve in terms of a scientific question to be answered by the analysis of data collected during the study.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "A goal for the study",
+        "type": "array"
+      },
+      "outcomeMeasure": {
+        "description": "[Text representation of ResearchStudyOutcomeMeasure] An \"outcome measure\", \"endpoint\", \"effect measure\" or \"measure of effect\" is a specific measurement or observation used to quantify the effect of experimental variables on the participants in a study, or for observational studies, to describe patterns of diseases or traits or associations with exposures, risk factors or treatment.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "A variable measured during the study",
+        "type": "array"
+      },
+      "partOf": {
+        "backref": "partOf_research_study",
+        "description": "[Text representation of Reference] A larger research study of which this particular study is a component or step.",
+        "element_property": true,
+        "enum_reference_types": [
+          "ResearchStudy"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Part of larger study",
+        "type": "array"
+      },
+      "period": {
+        "description": "[Text representation of Period] Identifies the start date and the expected (or actual, depending on status) end date for the study.",
+        "element_property": true,
+        "title": "When the study began and ended",
+        "type": "string"
+      },
+      "phase": {
+        "binding_description": "Codes for the stage in the progression of a therapy from initial experimental use in humans in clinical trials to post-market evaluation.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-phase",
+        "binding_version": null,
+        "description": "text representation. The stage in the progression of a therapy from initial experimental use in humans in clinical trials to post-market evaluation.",
+        "element_property": true,
+        "term": {
+          "description": "Codes for the stage in the progression of a therapy from initial experimental use in humans in clinical trials to post-market evaluation.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-phase",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-phase",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-phase"
+          }
+        },
+        "title": "n-a | early-phase-1 | phase-1 | phase-1-phase-2 | phase-2 | phase-2-phase-3 | phase-3 | phase-4",
+        "type": "string"
+      },
+      "phase_coding": {
+        "binding_description": "Codes for the stage in the progression of a therapy from initial experimental use in humans in clinical trials to post-market evaluation.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-phase",
+        "binding_version": null,
+        "description": "[system#code representation.] The stage in the progression of a therapy from initial experimental use in humans in clinical trials to post-market evaluation.",
+        "element_property": true,
+        "term": {
+          "description": "Codes for the stage in the progression of a therapy from initial experimental use in humans in clinical trials to post-market evaluation.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-phase",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-phase",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-phase"
+          }
+        },
+        "title": "n-a | early-phase-1 | phase-1 | phase-1-phase-2 | phase-2 | phase-2-phase-3 | phase-3 | phase-4",
+        "type": "string"
+      },
+      "phase_text": {
+        "binding_description": "Codes for the stage in the progression of a therapy from initial experimental use in humans in clinical trials to post-market evaluation.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-phase",
+        "binding_version": null,
+        "description": "[system#code representation.] The stage in the progression of a therapy from initial experimental use in humans in clinical trials to post-market evaluation.",
+        "element_property": true,
+        "term": {
+          "description": "Codes for the stage in the progression of a therapy from initial experimental use in humans in clinical trials to post-market evaluation.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-phase",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-phase",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-phase"
+          }
+        },
+        "title": "n-a | early-phase-1 | phase-1 | phase-1-phase-2 | phase-2 | phase-2-phase-3 | phase-3 | phase-4",
+        "type": "string"
+      },
+      "primaryPurposeType": {
+        "binding_description": "Codes for the main intent of the study.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type",
+        "binding_version": null,
+        "description": "text representation. The type of study based upon the intent of the study activities. A classification of the intent of the study.",
+        "element_property": true,
+        "term": {
+          "description": "Codes for the main intent of the study.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type"
+          }
+        },
+        "title": "treatment | prevention | diagnostic | supportive-care | screening | health-services-research | basic-science | device-feasibility",
+        "type": "string"
+      },
+      "primaryPurposeType_coding": {
+        "binding_description": "Codes for the main intent of the study.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type",
+        "binding_version": null,
+        "description": "[system#code representation.] The type of study based upon the intent of the study activities. A classification of the intent of the study.",
+        "element_property": true,
+        "term": {
+          "description": "Codes for the main intent of the study.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type"
+          }
+        },
+        "title": "treatment | prevention | diagnostic | supportive-care | screening | health-services-research | basic-science | device-feasibility",
+        "type": "string"
+      },
+      "primaryPurposeType_text": {
+        "binding_description": "Codes for the main intent of the study.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type",
+        "binding_version": null,
+        "description": "[system#code representation.] The type of study based upon the intent of the study activities. A classification of the intent of the study.",
+        "element_property": true,
+        "term": {
+          "description": "Codes for the main intent of the study.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-prim-purp-type"
+          }
+        },
+        "title": "treatment | prevention | diagnostic | supportive-care | screening | health-services-research | basic-science | device-feasibility",
+        "type": "string"
+      },
+      "progressStatus": {
+        "description": "[Text representation of ResearchStudyProgressStatus] Status of study with time for that status",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Status of study with time for that status",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "protocol": {
+        "backref": "protocol_research_study",
+        "description": "[Text representation of Reference] The set of steps expected to be performed as part of the execution of the study.",
+        "element_property": true,
+        "enum_reference_types": [
+          "PlanDefinition"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Steps followed in executing study",
+        "type": "array"
+      },
+      "recruitment": {
+        "description": "[Text representation of ResearchStudyRecruitment] Target or actual group of participants enrolled in study",
+        "element_property": true,
+        "title": "Target or actual group of participants enrolled in study",
+        "type": "string"
+      },
+      "region": {
+        "binding_description": "Countries and regions within which this artifact is targeted for use.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/jurisdiction",
+        "binding_version": null,
+        "description": "text representation. A country, state or other area where the study is taking place rather than its precise geographic location or address.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Countries and regions within which this artifact is targeted for use.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/jurisdiction",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/jurisdiction",
+            "term_url": "http://hl7.org/fhir/ValueSet/jurisdiction"
+          }
+        },
+        "title": "Geographic area for the study",
+        "type": "array"
+      },
+      "region_coding": {
+        "binding_description": "Countries and regions within which this artifact is targeted for use.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/jurisdiction",
+        "binding_version": null,
+        "description": "[system#code representation.] A country, state or other area where the study is taking place rather than its precise geographic location or address.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Countries and regions within which this artifact is targeted for use.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/jurisdiction",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/jurisdiction",
+            "term_url": "http://hl7.org/fhir/ValueSet/jurisdiction"
+          }
+        },
+        "title": "Geographic area for the study",
+        "type": "array"
+      },
+      "region_text": {
+        "binding_description": "Countries and regions within which this artifact is targeted for use.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/jurisdiction",
+        "binding_version": null,
+        "description": "[system#code representation.] A country, state or other area where the study is taking place rather than its precise geographic location or address.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Countries and regions within which this artifact is targeted for use.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/jurisdiction",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/jurisdiction",
+            "term_url": "http://hl7.org/fhir/ValueSet/jurisdiction"
+          }
+        },
+        "title": "Geographic area for the study",
+        "type": "array"
+      },
+      "relatedArtifact": {
+        "description": "[Text representation of RelatedArtifact] Citations, references, URLs and other related documents.  When using relatedArtifact to share URLs, the relatedArtifact.type will often be set to one of \"documentation\" or \"supported-with\" and the URL value will often be in relatedArtifact.document.url but another possible location is relatedArtifact.resource when it is a canonical URL.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "References, URLs, and attachments",
+        "type": "array"
+      },
+      "resourceType": {
+        "const": "ResearchStudy",
+        "default": "ResearchStudy",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "result": {
+        "backref": "result_research_study",
+        "description": "[Text representation of Reference] Link to one or more sets of results generated by the study.  Could also link to a research registry holding the results such as ClinicalTrials.gov.",
+        "element_property": true,
+        "enum_reference_types": [
+          "EvidenceReport",
+          "Citation",
+          "DiagnosticReport"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Link to results generated during the study",
+        "type": "array"
+      },
+      "site": {
+        "backref": "site_research_study",
+        "description": "[Text representation of Reference] A facility in which study activities are conducted.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Location",
+          "ResearchStudy",
+          "Organization"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Facility where study activities are conducted",
+        "type": "array"
+      },
+      "status": {
+        "binding_description": "Codes that convey the current publication status of the research study resource.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/publication-status",
+        "binding_version": "5.0.0",
+        "description": "The publication state of the resource (not of the study).",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "draft",
+          "active",
+          "retired",
+          "unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "draft | active | retired | unknown",
+        "type": "string"
+      },
+      "studyDesign": {
+        "binding_description": "This is a set of terms for study design characteristics.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/study-design",
+        "binding_version": null,
+        "description": "text representation. Codes categorizing the type of study such as investigational vs. observational, type of blinding, type of randomization, safety vs. efficacy, etc.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "This is a set of terms for study design characteristics.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/study-design",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/study-design",
+            "term_url": "http://hl7.org/fhir/ValueSet/study-design"
+          }
+        },
+        "title": "Classifications of the study design characteristics",
+        "type": "array"
+      },
+      "studyDesign_coding": {
+        "binding_description": "This is a set of terms for study design characteristics.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/study-design",
+        "binding_version": null,
+        "description": "[system#code representation.] Codes categorizing the type of study such as investigational vs. observational, type of blinding, type of randomization, safety vs. efficacy, etc.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "This is a set of terms for study design characteristics.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/study-design",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/study-design",
+            "term_url": "http://hl7.org/fhir/ValueSet/study-design"
+          }
+        },
+        "title": "Classifications of the study design characteristics",
+        "type": "array"
+      },
+      "studyDesign_text": {
+        "binding_description": "This is a set of terms for study design characteristics.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/study-design",
+        "binding_version": null,
+        "description": "[system#code representation.] Codes categorizing the type of study such as investigational vs. observational, type of blinding, type of randomization, safety vs. efficacy, etc.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "This is a set of terms for study design characteristics.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/study-design",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/study-design",
+            "term_url": "http://hl7.org/fhir/ValueSet/study-design"
+          }
+        },
+        "title": "Classifications of the study design characteristics",
+        "type": "array"
+      },
+      "title": {
+        "description": "The human readable name of the research study.",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Human readable name of the study",
+        "type": "string"
+      },
+      "url": {
+        "description": "Canonical identifier for this study resource, represented as a globally unique URI.",
+        "element_property": true,
+        "pattern": "\\S*",
+        "title": "Canonical identifier for this study resource",
+        "type": "string"
+      },
+      "version": {
+        "description": "The business version for the study record",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "The business version for the study record",
+        "type": "string"
+      },
+      "whyStopped": {
+        "binding_description": "Codes for why the study ended prematurely.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped",
+        "binding_version": null,
+        "description": "text representation. A description and/or code explaining the premature termination of the study.",
+        "element_property": true,
+        "term": {
+          "description": "Codes for why the study ended prematurely.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped"
+          }
+        },
+        "title": "accrual-goal-met | closed-due-to-toxicity | closed-due-to-lack-of-study-progress | temporarily-closed-per-study-design",
+        "type": "string"
+      },
+      "whyStopped_coding": {
+        "binding_description": "Codes for why the study ended prematurely.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped",
+        "binding_version": null,
+        "description": "[system#code representation.] A description and/or code explaining the premature termination of the study.",
+        "element_property": true,
+        "term": {
+          "description": "Codes for why the study ended prematurely.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped"
+          }
+        },
+        "title": "accrual-goal-met | closed-due-to-toxicity | closed-due-to-lack-of-study-progress | temporarily-closed-per-study-design",
+        "type": "string"
+      },
+      "whyStopped_text": {
+        "binding_description": "Codes for why the study ended prematurely.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped",
+        "binding_version": null,
+        "description": "[system#code representation.] A description and/or code explaining the premature termination of the study.",
+        "element_property": true,
+        "term": {
+          "description": "Codes for why the study ended prematurely.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped",
+            "term_url": "http://hl7.org/fhir/ValueSet/research-study-reason-stopped"
+          }
+        },
+        "title": "accrual-goal-met | closed-due-to-toxicity | closed-due-to-lack-of-study-progress | temporarily-closed-per-study-design",
+        "type": "string"
+      }
+    },
+    "title": "ResearchStudy",
+    "type": "object"
+  },
+  "patient.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Administrative",
+    "description": "Information about an individual or animal receiving health care services. Demographics and other administrative information about an individual or animal receiving care or other health-related services. [See https://hl7.org/fhir/R5/Patient.html]",
+    "id": "patient",
+    "links": [
+      {
+        "backref": "generalPractitioner_patient",
+        "label": "Patient_generalPractitioner_Organization_generalPractitioner_patient",
+        "multiplicity": "many_to_many",
+        "name": "generalPractitioner_Organization",
+        "required": false,
+        "target_type": "organization"
+      },
+      {
+        "backref": "generalPractitioner_patient",
+        "label": "Patient_generalPractitioner_Practitioner_generalPractitioner_patient",
+        "multiplicity": "many_to_many",
+        "name": "generalPractitioner_Practitioner",
+        "required": false,
+        "target_type": "practitioner"
+      },
+      {
+        "backref": "generalPractitioner_patient",
+        "label": "Patient_generalPractitioner_PractitionerRole_generalPractitioner_patient",
+        "multiplicity": "many_to_many",
+        "name": "generalPractitioner_PractitionerRole",
+        "required": false,
+        "target_type": "practitioner_role"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "active": {
+        "description": "Whether this patient record is in active use.  Many systems use this property to mark as non-current patients, such as those that have not been seen for a period of time based on an organization's business rules.  It is often used to filter patient lists to exclude inactive patients  Deceased patients may also be marked as inactive for the same reasons, but may be active for some time after death.",
+        "element_property": true,
+        "title": "Whether this patient's record is in active use",
+        "type": "boolean"
+      },
+      "address_postalCode": {
+        "description": "[Plucked from Patient.address] A postal code designating a region defined by the postal service.",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Postal code for area",
+        "type": "string"
+      },
+      "birthDate": {
+        "description": "The date of birth for the individual",
+        "element_property": true,
+        "format": "date",
+        "title": "The date of birth for the individual",
+        "type": "string"
+      },
+      "communication": {
+        "description": "[Text representation of PatientCommunication] A language which may be used to communicate with the patient about his or her health",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "A language which may be used to communicate with the patient about his or her health",
+        "type": "array"
+      },
+      "contact": {
+        "description": "[Text representation of PatientContact] A contact party (e.g. guardian, partner, friend) for the patient",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "A contact party (e.g. guardian, partner, friend) for the patient",
+        "type": "array"
+      },
+      "deceasedBoolean": {
+        "description": "Indicates if the individual is deceased or not",
+        "element_property": true,
+        "one_of_many": "deceased",
+        "one_of_many_required": false,
+        "title": "Indicates if the individual is deceased or not",
+        "type": "boolean"
+      },
+      "deceasedDateTime": {
+        "description": "Indicates if the individual is deceased or not",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "deceased",
+        "one_of_many_required": false,
+        "title": "Indicates if the individual is deceased or not",
+        "type": "string"
+      },
+      "disability_adjusted_life_years": {
+        "description": "[extension disability_adjusted_life_years] Disability Adjusted Life Years as defined in the literature and summarized at <a href=\"https://en.wikipedia.org/wiki/Disability-adjusted_life_year\"/>.",
+        "type": "number"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "gender": {
+        "binding_description": "The gender of a person used for administrative purposes.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/administrative-gender",
+        "binding_version": "5.0.0",
+        "description": "Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes.",
+        "element_property": true,
+        "enum_values": [
+          "male",
+          "female",
+          "other",
+          "unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "male | female | other | unknown",
+        "type": "string"
+      },
+      "generalPractitioner": {
+        "backref": "generalPractitioner_patient",
+        "description": "[Text representation of Reference] Patient's nominated care provider.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization",
+          "Practitioner",
+          "PractitionerRole"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Patient's nominated primary care provider",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "An identifier for this patient",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "An identifier for this patient",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] An identifier for this patient",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "An identifier for this patient",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] An identifier for this patient",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "An identifier for this patient",
+        "type": "array"
+      },
+      "link": {
+        "description": "[Text representation of PatientLink] Link to a Patient or RelatedPerson resource that concerns the same actual individual",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Link to a Patient or RelatedPerson resource that concerns the same actual individual",
+        "type": "array"
+      },
+      "managingOrganization": {
+        "backref": "managingOrganization_patient",
+        "description": "[Text representation of Reference] Organization that is the custodian of the patient record",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "Organization that is the custodian of the patient record",
+        "type": "string"
+      },
+      "maritalStatus": {
+        "binding_description": "The domestic partnership status of a person.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/marital-status",
+        "binding_version": null,
+        "description": "text representation. This field contains a patient's most recent marital (civil) status.",
+        "element_property": true,
+        "term": {
+          "description": "The domestic partnership status of a person.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/marital-status",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/marital-status",
+            "term_url": "http://hl7.org/fhir/ValueSet/marital-status"
+          }
+        },
+        "title": "Marital (civil) status of a patient",
+        "type": "string"
+      },
+      "maritalStatus_coding": {
+        "binding_description": "The domestic partnership status of a person.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/marital-status",
+        "binding_version": null,
+        "description": "[system#code representation.] This field contains a patient's most recent marital (civil) status.",
+        "element_property": true,
+        "term": {
+          "description": "The domestic partnership status of a person.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/marital-status",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/marital-status",
+            "term_url": "http://hl7.org/fhir/ValueSet/marital-status"
+          }
+        },
+        "title": "Marital (civil) status of a patient",
+        "type": "string"
+      },
+      "maritalStatus_text": {
+        "binding_description": "The domestic partnership status of a person.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/marital-status",
+        "binding_version": null,
+        "description": "[system#code representation.] This field contains a patient's most recent marital (civil) status.",
+        "element_property": true,
+        "term": {
+          "description": "The domestic partnership status of a person.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/marital-status",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/marital-status",
+            "term_url": "http://hl7.org/fhir/ValueSet/marital-status"
+          }
+        },
+        "title": "Marital (civil) status of a patient",
+        "type": "string"
+      },
+      "multipleBirthBoolean": {
+        "description": "Indicates whether the patient is part of a multiple (boolean) or indicates the actual birth order (integer).",
+        "element_property": true,
+        "one_of_many": "multipleBirth",
+        "one_of_many_required": false,
+        "title": "Whether patient is part of a multiple birth",
+        "type": "boolean"
+      },
+      "multipleBirthInteger": {
+        "description": "Indicates whether the patient is part of a multiple (boolean) or indicates the actual birth order (integer).",
+        "element_property": true,
+        "one_of_many": "multipleBirth",
+        "one_of_many_required": false,
+        "title": "Whether patient is part of a multiple birth",
+        "type": "integer"
+      },
+      "name": {
+        "description": "[Text representation of HumanName] A name associated with the individual.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "A name associated with the patient",
+        "type": "array"
+      },
+      "patient_birthPlace": {
+        "description": "[Text representation of Address] [extension patient_birthPlace] The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements.",
+        "type": "string"
+      },
+      "patient_mothersMaidenName": {
+        "description": "[extension patient_mothersMaidenName] Mother's maiden (unmarried) name, commonly collected to help verify patient identity.",
+        "type": "string"
+      },
+      "photo": {
+        "description": "[Text representation of Attachment] Image of the patient",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Image of the patient",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "quality_adjusted_life_years": {
+        "description": "[extension quality_adjusted_life_years] Quality Adjusted Life Years as defined in the literature and summarized at <a href=\"https://en.wikipedia.org/wiki/Quality-adjusted_life_year\"/>.",
+        "type": "number"
+      },
+      "resourceType": {
+        "const": "Patient",
+        "default": "Patient",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "telecom": {
+        "description": "[Text representation of ContactPoint] A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "A contact detail for the individual",
+        "type": "array"
+      },
+      "us_core_birthsex": {
+        "binding_description": "Code for sex assigned at birth",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/us/core/ValueSet/birthsex",
+        "binding_version": null,
+        "description": "[extension us_core_birthsex] A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).",
+        "term": {
+          "description": "Code for sex assigned at birth",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/us/core/ValueSet/birthsex",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/us/core/ValueSet/birthsex",
+            "term_url": "http://hl7.org/fhir/us/core/ValueSet/birthsex"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_ethnicity": {
+        "description": "[extension us_core_ethnicity] Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+        "type": "string"
+      },
+      "us_core_ethnicity_detailed": {
+        "binding_description": null,
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity",
+        "binding_version": null,
+        "description": "[Text representation of Coding] [extension us_core_ethnicity] Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity",
+            "term_url": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_ethnicity_ombCategory": {
+        "binding_description": null,
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category",
+        "binding_version": null,
+        "description": "[Text representation of Coding] [extension us_core_ethnicity] Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category",
+            "term_url": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_genderIdentity": {
+        "binding_description": null,
+        "binding_strength": "extensible",
+        "binding_uri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32",
+        "binding_version": null,
+        "description": "text representation. [extension us_core_genderIdentity] This extension represents an individual's sense of being a man, woman, boy, girl, nonbinary, or something else, ascertained by asking them what that identity is. Systems requiring multiple gender identities and associated dates **SHOULD** use the FHIR R5 [genderIdentity extension](http://hl7.org/fhir/extensions/StructureDefinition-individual-genderIdentity.html). When future versions of US Core are based on FHIR R5, the FHIR R5 extension will supersede this extension.",
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32",
+            "term_url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_genderIdentity_coding": {
+        "binding_description": null,
+        "binding_strength": "extensible",
+        "binding_uri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32",
+        "binding_version": null,
+        "description": "[system#code representation.] [extension us_core_genderIdentity] This extension represents an individual's sense of being a man, woman, boy, girl, nonbinary, or something else, ascertained by asking them what that identity is. Systems requiring multiple gender identities and associated dates **SHOULD** use the FHIR R5 [genderIdentity extension](http://hl7.org/fhir/extensions/StructureDefinition-individual-genderIdentity.html). When future versions of US Core are based on FHIR R5, the FHIR R5 extension will supersede this extension.",
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32",
+            "term_url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_genderIdentity_text": {
+        "binding_description": null,
+        "binding_strength": "extensible",
+        "binding_uri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32",
+        "binding_version": null,
+        "description": "[system#code representation.] [extension us_core_genderIdentity] This extension represents an individual's sense of being a man, woman, boy, girl, nonbinary, or something else, ascertained by asking them what that identity is. Systems requiring multiple gender identities and associated dates **SHOULD** use the FHIR R5 [genderIdentity extension](http://hl7.org/fhir/extensions/StructureDefinition-individual-genderIdentity.html). When future versions of US Core are based on FHIR R5, the FHIR R5 extension will supersede this extension.",
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32",
+            "term_url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_race": {
+        "description": "[extension us_core_race] Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
+        "type": "string"
+      },
+      "us_core_race_detailed": {
+        "binding_description": null,
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/us/core/ValueSet/detailed-race",
+        "binding_version": null,
+        "description": "[Text representation of Coding] [extension us_core_race] Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/us/core/ValueSet/detailed-race",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/us/core/ValueSet/detailed-race",
+            "term_url": "http://hl7.org/fhir/us/core/ValueSet/detailed-race"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_race_ombCategory": {
+        "binding_description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category",
+        "binding_version": null,
+        "description": "[Text representation of Coding] [extension us_core_race] Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
+        "term": {
+          "description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category",
+            "term_url": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_tribal_affiliation_isEnrolled": {
+        "description": "[extension us_core_tribal_affiliation] This Extension profile represents a tribe or band with which a person associates and, optionally, whether they are enrolled.",
+        "type": "boolean"
+      },
+      "us_core_tribal_affiliation_tribalAffiliation": {
+        "binding_description": "Tribal Entity recognized by the United States Bureau Of Indian Affairs.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS",
+        "binding_version": null,
+        "description": "text representation. [extension us_core_tribal_affiliation] This Extension profile represents a tribe or band with which a person associates and, optionally, whether they are enrolled.",
+        "term": {
+          "description": "Tribal Entity recognized by the United States Bureau Of Indian Affairs.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_tribal_affiliation_tribalAffiliation_coding": {
+        "binding_description": "Tribal Entity recognized by the United States Bureau Of Indian Affairs.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS",
+        "binding_version": null,
+        "description": "[system#code representation.] [extension us_core_tribal_affiliation] This Extension profile represents a tribe or band with which a person associates and, optionally, whether they are enrolled.",
+        "term": {
+          "description": "Tribal Entity recognized by the United States Bureau Of Indian Affairs.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS"
+          }
+        },
+        "type": "string"
+      },
+      "us_core_tribal_affiliation_tribalAffiliation_text": {
+        "binding_description": "Tribal Entity recognized by the United States Bureau Of Indian Affairs.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS",
+        "binding_version": null,
+        "description": "[system#code representation.] [extension us_core_tribal_affiliation] This Extension profile represents a tribe or band with which a person associates and, optionally, whether they are enrolled.",
+        "term": {
+          "description": "Tribal Entity recognized by the United States Bureau Of Indian Affairs.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-TribalEntityUS"
+          }
+        },
+        "type": "string"
+      }
+    },
+    "title": "Patient",
+    "type": "object"
+  },
+  "practitioner.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Administrative",
+    "description": "A person with a  formal responsibility in the provisioning of healthcare or related services. A person who is directly or indirectly involved in the provisioning of healthcare or related services. [See https://hl7.org/fhir/R5/Practitioner.html]",
+    "id": "practitioner",
+    "links": [],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "active": {
+        "description": "Whether this practitioner's record is in active use",
+        "element_property": true,
+        "title": "Whether this practitioner's record is in active use",
+        "type": "boolean"
+      },
+      "address": {
+        "description": "[Text representation of Address] Address(es) of the practitioner that are not role specific (typically home address).  Work addresses are not typically entered in this property as they are usually role dependent.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Address(es) of the practitioner that are not role specific (typically home address)",
+        "type": "array"
+      },
+      "birthDate": {
+        "description": "The date of birth for the practitioner.",
+        "element_property": true,
+        "format": "date",
+        "title": "The date  on which the practitioner was born",
+        "type": "string"
+      },
+      "communication": {
+        "description": "[Text representation of PractitionerCommunication] A language which may be used to communicate with the practitioner, often for correspondence/administrative purposes.  The `PractitionerRole.communication` property should be used for publishing the languages that a practitioner is able to communicate with patients (on a per Organization/Role basis).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "A language which may be used to communicate with the practitioner",
+        "type": "array"
+      },
+      "deceasedBoolean": {
+        "description": "Indicates if the practitioner is deceased or not",
+        "element_property": true,
+        "one_of_many": "deceased",
+        "one_of_many_required": false,
+        "title": "Indicates if the practitioner is deceased or not",
+        "type": "boolean"
+      },
+      "deceasedDateTime": {
+        "description": "Indicates if the practitioner is deceased or not",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "deceased",
+        "one_of_many_required": false,
+        "title": "Indicates if the practitioner is deceased or not",
+        "type": "string"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "gender": {
+        "binding_description": "The gender of a person used for administrative purposes.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/administrative-gender",
+        "binding_version": "5.0.0",
+        "description": "Administrative Gender - the gender that the person is considered to have for administration and record keeping purposes.",
+        "element_property": true,
+        "enum_values": [
+          "male",
+          "female",
+          "other",
+          "unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "male | female | other | unknown",
+        "type": "string"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "An identifier that applies to this person in this role.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "An identifier for the person as this agent",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] An identifier that applies to this person in this role.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "An identifier for the person as this agent",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] An identifier that applies to this person in this role.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "An identifier for the person as this agent",
+        "type": "array"
+      },
+      "name": {
+        "description": "[Text representation of HumanName] The name(s) associated with the practitioner",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "The name(s) associated with the practitioner",
+        "type": "array"
+      },
+      "photo": {
+        "description": "[Text representation of Attachment] Image of the person",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Image of the person",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "qualification": {
+        "description": "[Text representation of PractitionerQualification] The official qualifications, certifications, accreditations, training, licenses (and other types of educations/skills/capabilities) that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board of licensure authorizing the practitioner to practice medicine within a certain locality.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Qualifications, certifications, accreditations, licenses, training, etc. pertaining to the provision of care",
+        "type": "array"
+      },
+      "resourceType": {
+        "const": "Practitioner",
+        "default": "Practitioner",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "telecom": {
+        "description": "[Text representation of ContactPoint] A contact detail for the practitioner, e.g. a telephone number or an email address.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "A contact detail for the practitioner (that apply to all roles)",
+        "type": "array"
+      }
+    },
+    "title": "Practitioner",
+    "type": "object"
+  },
+  "substance.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "A homogeneous material with a definite composition. [See https://hl7.org/fhir/R5/Substance.html]",
+    "id": "substance",
+    "links": [],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "category": {
+        "binding_description": "Category or classification of substance.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/substance-category",
+        "binding_version": null,
+        "description": "text representation. A code that classifies the general type of substance.  This is used  for searching, sorting and display purposes.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Category or classification of substance.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/substance-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/substance-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/substance-category"
+          }
+        },
+        "title": "What class/type of substance this is",
+        "type": "array"
+      },
+      "category_coding": {
+        "binding_description": "Category or classification of substance.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/substance-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A code that classifies the general type of substance.  This is used  for searching, sorting and display purposes.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Category or classification of substance.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/substance-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/substance-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/substance-category"
+          }
+        },
+        "title": "What class/type of substance this is",
+        "type": "array"
+      },
+      "category_text": {
+        "binding_description": "Category or classification of substance.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/substance-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A code that classifies the general type of substance.  This is used  for searching, sorting and display purposes.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Category or classification of substance.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/substance-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/substance-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/substance-category"
+          }
+        },
+        "title": "What class/type of substance this is",
+        "type": "array"
+      },
+      "code": {
+        "backref": "substance",
+        "binding_description": "Substance codes.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/substance-code",
+        "binding_version": null,
+        "description": "text representation. A code (or set of codes) that identify this substance.",
+        "element_property": true,
+        "enum_reference_types": [
+          "SubstanceDefinition"
+        ],
+        "term": {
+          "description": "Substance codes.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/substance-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/substance-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/substance-code"
+          }
+        },
+        "title": "What substance this is",
+        "type": "string"
+      },
+      "code_coding": {
+        "backref": "substance",
+        "binding_description": "Substance codes.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/substance-code",
+        "binding_version": null,
+        "description": "[system#code representation.] A code (or set of codes) that identify this substance.",
+        "element_property": true,
+        "enum_reference_types": [
+          "SubstanceDefinition"
+        ],
+        "term": {
+          "description": "Substance codes.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/substance-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/substance-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/substance-code"
+          }
+        },
+        "title": "What substance this is",
+        "type": "string"
+      },
+      "code_text": {
+        "backref": "substance",
+        "binding_description": "Substance codes.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/substance-code",
+        "binding_version": null,
+        "description": "[system#code representation.] A code (or set of codes) that identify this substance.",
+        "element_property": true,
+        "enum_reference_types": [
+          "SubstanceDefinition"
+        ],
+        "term": {
+          "description": "Substance codes.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/substance-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/substance-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/substance-code"
+          }
+        },
+        "title": "What substance this is",
+        "type": "string"
+      },
+      "description": {
+        "description": "A description of the substance - its appearance, handling requirements, and other usage notes.",
+        "element_property": true,
+        "pattern": "\\s*(\\S|\\s)*",
+        "title": "Textual description of the substance, comments",
+        "type": "string"
+      },
+      "expiry": {
+        "description": "When the substance is no longer valid to use. For some substances, a single arbitrary date is used for expiry.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "When no longer valid to use",
+        "type": "string"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Unique identifier for the substance. For an instance, an identifier associated with the package/container (usually a label affixed directly).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Unique identifier",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Unique identifier for the substance. For an instance, an identifier associated with the package/container (usually a label affixed directly).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Unique identifier",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Unique identifier for the substance. For an instance, an identifier associated with the package/container (usually a label affixed directly).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Unique identifier",
+        "type": "array"
+      },
+      "ingredient": {
+        "description": "[Text representation of SubstanceIngredient] A substance can be composed of other substances.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Composition information about the substance",
+        "type": "array"
+      },
+      "instance": {
+        "description": "A boolean to indicate if this an instance of a substance or a kind of one (a definition).",
+        "element_property": true,
+        "element_required": true,
+        "title": "Is this an instance of a substance or a kind of one",
+        "type": "boolean"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "quantity": {
+        "description": "[Text representation of Quantity] text representation. The amount of the substance.",
+        "element_property": true,
+        "title": "Amount of substance in the package",
+        "type": "string"
+      },
+      "quantity_unit": {
+        "title": "Unit representation. Amount of substance in the package",
+        "type": "string"
+      },
+      "quantity_value": {
+        "title": "Numerical value (with implicit precision) representation. Amount of substance in the package",
+        "type": "number"
+      },
+      "resourceType": {
+        "const": "Substance",
+        "default": "Substance",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "A code to indicate if the substance is actively used.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/substance-status",
+        "binding_version": "5.0.0",
+        "description": "A code to indicate if the substance is actively used.",
+        "element_property": true,
+        "enum_values": [
+          "active",
+          "inactive",
+          "entered-in-error"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "active | inactive | entered-in-error",
+        "type": "string"
+      }
+    },
+    "title": "Substance",
+    "type": "object"
+  },
+  "_program.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
+    "category": "administrative",
+    "description": "A broad framework of goals to be achieved. (NCIt C52647)\n",
+    "id": "program",
+    "links": [],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "dbgap_accession_number": {
+        "description": "The dbgap accession number provided for the program.",
+        "type": "string"
+      },
+      "id": {
+        "$ref": "_definitions.yaml#/UUID",
+        "systemAlias": "node_id"
+      },
+      "name": {
+        "description": "Full name/title of the program.",
+        "type": "string"
+      },
+      "type": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "dbgap_accession_number"
+    ],
+    "submittable": false,
+    "systemProperties": [
+      "id"
+    ],
+    "title": "Program",
+    "type": "object",
+    "uniqueKeys": [
+      [
+        "id"
+      ],
+      [
+        "name"
+      ]
+    ],
+    "validators": null
+  },
+  "_project.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
+    "category": "administrative",
+    "constraints": null,
+    "description": "Any specifically defined piece of work that is undertaken or attempted to meet a single requirement. (NCIt C47885)\n",
+    "id": "project",
+    "links": [
+      {
+        "backref": "projects",
+        "label": "member_of",
+        "multiplicity": "many_to_one",
+        "name": "programs",
+        "required": true,
+        "target_type": "program"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "availability_mechanism": {
+        "description": "Mechanism by which the project will be made avilable.",
+        "type": "string"
+      },
+      "availability_type": {
+        "description": "Is the project open or restricted?",
+        "enum": [
+          "Open",
+          "Restricted"
+        ]
+      },
+      "code": {
+        "description": "Unique identifier for the project.",
+        "type": "string"
+      },
+      "date_collected": {
+        "description": "The date or date range in which the project data was collected.",
+        "type": "string"
+      },
+      "dbgap_accession_number": {
+        "description": "The dbgap accession number provided for the project.",
+        "type": "string"
+      },
+      "id": {
+        "$ref": "_definitions.yaml#/UUID",
+        "description": "UUID for the project.",
+        "systemAlias": "node_id"
+      },
+      "intended_release_date": {
+        "description": "Tracks a Project's intended release date.",
+        "format": "date-time",
+        "type": "string"
+      },
+      "investigator_affiliation": {
+        "description": "The investigator's affiliation with respect to a research institution.",
+        "type": "string"
+      },
+      "investigator_name": {
+        "description": "Name of the principal investigator for the project.",
+        "type": "string"
+      },
+      "name": {
+        "description": "Display name/brief description for the project.",
+        "type": "string"
+      },
+      "programs": {
+        "$ref": "_definitions.yaml#/to_one",
+        "description": "Indicates that the project is logically part of the indicated project.\n"
+      },
+      "releasable": {
+        "default": false,
+        "description": "A project can only be released by the user when `releasable` is true.\n",
+        "type": "boolean"
+      },
+      "released": {
+        "default": false,
+        "description": "To release a project is to tell the GDC to include all submitted\nentities in the next GDC index.\n",
+        "type": "boolean"
+      },
+      "state": {
+        "default": "open",
+        "description": "The possible states a project can be in.  All but `open` are\nequivalent to some type of locked state.\n",
+        "enum": [
+          "open",
+          "review",
+          "submitted",
+          "processing",
+          "closed",
+          "legacy"
+        ]
+      },
+      "support_id": {
+        "description": "The ID of the source providing support/grant resources.",
+        "type": "string"
+      },
+      "support_source": {
+        "description": "The name of source providing support/grant resources.",
+        "type": "string"
+      },
+      "type": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "code",
+      "name",
+      "dbgap_accession_number",
+      "programs"
+    ],
+    "submittable": true,
+    "systemProperties": [
+      "id",
+      "state",
+      "released",
+      "releasable",
+      "intended_release_date"
+    ],
+    "title": "Project",
+    "type": "object",
+    "uniqueKeys": [
+      [
+        "id"
+      ],
+      [
+        "code"
+      ]
+    ],
+    "validators": null
+  },
+  "immunization.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "Immunization event information. Describes the event of a patient being administered a vaccine or a record of an immunization as reported by a patient, a clinician or another party. [See https://hl7.org/fhir/R5/Immunization.html]",
+    "id": "immunization",
+    "links": [
+      {
+        "backref": "immunization",
+        "label": "Immunization_administeredProduct_Medication_immunization",
+        "multiplicity": "many_to_many",
+        "name": "administeredProduct",
+        "required": false,
+        "target_type": "medication"
+      },
+      {
+        "backref": "immunization",
+        "label": "Immunization_encounter_Encounter_immunization",
+        "multiplicity": "many_to_many",
+        "name": "encounter",
+        "required": false,
+        "target_type": "encounter"
+      },
+      {
+        "backref": "informationSource_immunization",
+        "label": "Immunization_informationSource_Patient_informationSource_immunization",
+        "multiplicity": "many_to_many",
+        "name": "informationSource_Patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "informationSource_immunization",
+        "label": "Immunization_informationSource_Practitioner_informationSource_immunization",
+        "multiplicity": "many_to_many",
+        "name": "informationSource_Practitioner",
+        "required": false,
+        "target_type": "practitioner"
+      },
+      {
+        "backref": "informationSource_immunization",
+        "label": "Immunization_informationSource_PractitionerRole_informationSource_immunization",
+        "multiplicity": "many_to_many",
+        "name": "informationSource_PractitionerRole",
+        "required": false,
+        "target_type": "practitioner_role"
+      },
+      {
+        "backref": "informationSource_immunization",
+        "label": "Immunization_informationSource_Organization_informationSource_immunization",
+        "multiplicity": "many_to_many",
+        "name": "informationSource_Organization",
+        "required": false,
+        "target_type": "organization"
+      },
+      {
+        "backref": "immunization",
+        "label": "Immunization_location_Location_immunization",
+        "multiplicity": "many_to_many",
+        "name": "location",
+        "required": false,
+        "target_type": "location"
+      },
+      {
+        "backref": "reason_immunization",
+        "label": "Immunization_reason_Condition_reason_immunization",
+        "multiplicity": "many_to_many",
+        "name": "reason_Condition",
+        "required": false,
+        "target_type": "condition"
+      },
+      {
+        "backref": "reason_immunization",
+        "label": "Immunization_reason_Observation_reason_immunization",
+        "multiplicity": "many_to_many",
+        "name": "reason_Observation",
+        "required": false,
+        "target_type": "observation"
+      },
+      {
+        "backref": "reason_immunization",
+        "label": "Immunization_reason_DiagnosticReport_reason_immunization",
+        "multiplicity": "many_to_many",
+        "name": "reason_DiagnosticReport",
+        "required": false,
+        "target_type": "diagnostic_report"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "administeredProduct": {
+        "backref": "immunization",
+        "description": "text representation. An indication of which product was administered to the patient. This is typically a more detailed representation of the concept conveyed by the vaccineCode data element. If a Medication resource is referenced, it may be to a stand-alone resource or a contained resource within the Immunization resource.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Medication"
+        ],
+        "title": "Product that was administered",
+        "type": "string"
+      },
+      "administeredProduct_coding": {
+        "backref": "immunization",
+        "description": "[system#code representation.] An indication of which product was administered to the patient. This is typically a more detailed representation of the concept conveyed by the vaccineCode data element. If a Medication resource is referenced, it may be to a stand-alone resource or a contained resource within the Immunization resource.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Medication"
+        ],
+        "title": "Product that was administered",
+        "type": "string"
+      },
+      "administeredProduct_text": {
+        "backref": "immunization",
+        "description": "[system#code representation.] An indication of which product was administered to the patient. This is typically a more detailed representation of the concept conveyed by the vaccineCode data element. If a Medication resource is referenced, it may be to a stand-alone resource or a contained resource within the Immunization resource.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Medication"
+        ],
+        "title": "Product that was administered",
+        "type": "string"
+      },
+      "basedOn": {
+        "backref": "basedOn_immunization",
+        "description": "[Text representation of Reference] A plan, order or recommendation fulfilled in whole or in part by this immunization.",
+        "element_property": true,
+        "enum_reference_types": [
+          "CarePlan",
+          "MedicationRequest",
+          "ServiceRequest",
+          "ImmunizationRecommendation"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Authority that the immunization event is based on",
+        "type": "array"
+      },
+      "doseQuantity": {
+        "description": "[Text representation of Quantity] text representation. The quantity of vaccine product that was administered.",
+        "element_property": true,
+        "title": "Amount of vaccine administered",
+        "type": "string"
+      },
+      "doseQuantity_unit": {
+        "title": "Unit representation. Amount of vaccine administered",
+        "type": "string"
+      },
+      "doseQuantity_value": {
+        "title": "Numerical value (with implicit precision) representation. Amount of vaccine administered",
+        "type": "number"
+      },
+      "encounter": {
+        "backref": "immunization",
+        "description": "[Text representation of Reference] The visit or admission or other contact between patient and health care provider the immunization was performed as part of.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Encounter"
+        ],
+        "title": "Encounter immunization was part of",
+        "type": "string"
+      },
+      "expirationDate": {
+        "description": "Date vaccine batch expires.",
+        "element_property": true,
+        "format": "date",
+        "title": "Vaccine expiration date",
+        "type": "string"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "fundingSource": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-funding-source",
+        "binding_version": null,
+        "description": "text representation. Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-funding-source",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-funding-source",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-funding-source"
+          }
+        },
+        "title": "Funding source for the vaccine",
+        "type": "string"
+      },
+      "fundingSource_coding": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-funding-source",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-funding-source",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-funding-source",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-funding-source"
+          }
+        },
+        "title": "Funding source for the vaccine",
+        "type": "string"
+      },
+      "fundingSource_text": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-funding-source",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-funding-source",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-funding-source",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-funding-source"
+          }
+        },
+        "title": "Funding source for the vaccine",
+        "type": "string"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "A unique identifier assigned to this immunization record.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifier",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] A unique identifier assigned to this immunization record.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifier",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] A unique identifier assigned to this immunization record.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifier",
+        "type": "array"
+      },
+      "informationSource": {
+        "backref": "informationSource_immunization",
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-origin",
+        "binding_version": null,
+        "description": "text representation. Typically the source of the data when the report of the immunization event is not based on information from the person who administered the vaccine.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Practitioner",
+          "PractitionerRole",
+          "RelatedPerson",
+          "Organization"
+        ],
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-origin",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-origin",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-origin"
+          }
+        },
+        "title": "Indicates the source of a  reported record",
+        "type": "string"
+      },
+      "informationSource_coding": {
+        "backref": "informationSource_immunization",
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-origin",
+        "binding_version": null,
+        "description": "[system#code representation.] Typically the source of the data when the report of the immunization event is not based on information from the person who administered the vaccine.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Practitioner",
+          "PractitionerRole",
+          "RelatedPerson",
+          "Organization"
+        ],
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-origin",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-origin",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-origin"
+          }
+        },
+        "title": "Indicates the source of a  reported record",
+        "type": "string"
+      },
+      "informationSource_text": {
+        "backref": "informationSource_immunization",
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-origin",
+        "binding_version": null,
+        "description": "[system#code representation.] Typically the source of the data when the report of the immunization event is not based on information from the person who administered the vaccine.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Practitioner",
+          "PractitionerRole",
+          "RelatedPerson",
+          "Organization"
+        ],
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-origin",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-origin",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-origin"
+          }
+        },
+        "title": "Indicates the source of a  reported record",
+        "type": "string"
+      },
+      "isSubpotent": {
+        "description": "Indication if a dose is considered to be subpotent. By default, a dose should be considered to be potent.",
+        "element_property": true,
+        "title": "Dose potency",
+        "type": "boolean"
+      },
+      "location": {
+        "backref": "immunization",
+        "description": "[Text representation of Reference] The service delivery location where the vaccine administration occurred.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Location"
+        ],
+        "title": "Where immunization occurred",
+        "type": "string"
+      },
+      "lotNumber": {
+        "description": "Lot number of the  vaccine product.",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Vaccine lot number",
+        "type": "string"
+      },
+      "manufacturer": {
+        "backref": "manufacturer_immunization",
+        "description": "text representation. Name of vaccine manufacturer.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "Vaccine manufacturer",
+        "type": "string"
+      },
+      "manufacturer_coding": {
+        "backref": "manufacturer_immunization",
+        "description": "[system#code representation.] Name of vaccine manufacturer.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "Vaccine manufacturer",
+        "type": "string"
+      },
+      "manufacturer_text": {
+        "backref": "manufacturer_immunization",
+        "description": "[system#code representation.] Name of vaccine manufacturer.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "Vaccine manufacturer",
+        "type": "string"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] Extra information about the immunization that is not conveyed by the other attributes.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional immunization notes",
+        "type": "array"
+      },
+      "occurrenceDateTime": {
+        "description": "Date vaccine administered or was to be administered.",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "occurrence",
+        "one_of_many_required": true,
+        "title": "Vaccine administration date",
+        "type": "string"
+      },
+      "occurrenceString": {
+        "description": "Date vaccine administered or was to be administered.",
+        "element_property": true,
+        "one_of_many": "occurrence",
+        "one_of_many_required": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Vaccine administration date",
+        "type": "string"
+      },
+      "patient": {
+        "backref": "patient_immunization",
+        "description": "[Text representation of Reference] The patient who either received or did not receive the immunization.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient"
+        ],
+        "title": "Who was immunized",
+        "type": "string"
+      },
+      "performer": {
+        "description": "[Text representation of ImmunizationPerformer] Indicates who performed the immunization event.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Who performed event",
+        "type": "array"
+      },
+      "primarySource": {
+        "description": "Indicates whether the data contained in the resource was captured by the individual/organization which was responsible for the administration of the vaccine rather than as 'secondary reported' data documented by a third party. A value of 'true' means this data originated with the individual/organization which was responsible for the administration of the vaccine.",
+        "element_property": true,
+        "title": "Indicates context the data was captured in",
+        "type": "boolean"
+      },
+      "programEligibility": {
+        "description": "[Text representation of ImmunizationProgramEligibility] Indicates a patient's eligibility for a funding program.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Patient eligibility for a specific vaccination program",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "protocolApplied": {
+        "description": "[Text representation of ImmunizationProtocolApplied] The protocol (set of recommendations) being followed by the provider who administered the dose.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Protocol followed by the provider",
+        "type": "array"
+      },
+      "reaction": {
+        "description": "[Text representation of ImmunizationReaction] Categorical data indicating that an adverse event is associated in time to an immunization.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Details of a reaction that follows immunization",
+        "type": "array"
+      },
+      "reason": {
+        "backref": "reason_immunization",
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-reason",
+        "binding_version": null,
+        "description": "text representation. Describes why the immunization occurred in coded or textual form, or Indicates another resource (Condition, Observation or DiagnosticReport) whose existence justifies this immunization.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "DiagnosticReport"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-reason"
+          }
+        },
+        "title": "Why immunization occurred",
+        "type": "array"
+      },
+      "reason_coding": {
+        "backref": "reason_immunization",
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes why the immunization occurred in coded or textual form, or Indicates another resource (Condition, Observation or DiagnosticReport) whose existence justifies this immunization.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "DiagnosticReport"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-reason"
+          }
+        },
+        "title": "Why immunization occurred",
+        "type": "array"
+      },
+      "reason_text": {
+        "backref": "reason_immunization",
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes why the immunization occurred in coded or textual form, or Indicates another resource (Condition, Observation or DiagnosticReport) whose existence justifies this immunization.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "DiagnosticReport"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-reason"
+          }
+        },
+        "title": "Why immunization occurred",
+        "type": "array"
+      },
+      "resourceType": {
+        "const": "Immunization",
+        "default": "Immunization",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "route": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-route",
+        "binding_version": null,
+        "description": "text representation. The path by which the vaccine product is taken into the body.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-route",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-route",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-route"
+          }
+        },
+        "title": "How vaccine entered body",
+        "type": "string"
+      },
+      "route_coding": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-route",
+        "binding_version": null,
+        "description": "[system#code representation.] The path by which the vaccine product is taken into the body.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-route",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-route",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-route"
+          }
+        },
+        "title": "How vaccine entered body",
+        "type": "string"
+      },
+      "route_text": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-route",
+        "binding_version": null,
+        "description": "[system#code representation.] The path by which the vaccine product is taken into the body.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-route",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-route",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-route"
+          }
+        },
+        "title": "How vaccine entered body",
+        "type": "string"
+      },
+      "site": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-site",
+        "binding_version": null,
+        "description": "text representation. Body site where vaccine was administered.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-site"
+          }
+        },
+        "title": "Body site vaccine  was administered",
+        "type": "string"
+      },
+      "site_coding": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-site",
+        "binding_version": null,
+        "description": "[system#code representation.] Body site where vaccine was administered.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-site"
+          }
+        },
+        "title": "Body site vaccine  was administered",
+        "type": "string"
+      },
+      "site_text": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-site",
+        "binding_version": null,
+        "description": "[system#code representation.] Body site where vaccine was administered.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-site"
+          }
+        },
+        "title": "Body site vaccine  was administered",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "x",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-status",
+        "binding_version": "5.0.0",
+        "description": "Indicates the current status of the immunization event.",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "completed",
+          "entered-in-error",
+          "not-done"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "completed | entered-in-error | not-done",
+        "type": "string"
+      },
+      "statusReason": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-status-reason",
+        "binding_version": null,
+        "description": "text representation. Indicates the reason the immunization event was not performed.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-status-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-status-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
+          }
+        },
+        "title": "Reason for current status",
+        "type": "string"
+      },
+      "statusReason_coding": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-status-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the reason the immunization event was not performed.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-status-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-status-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
+          }
+        },
+        "title": "Reason for current status",
+        "type": "string"
+      },
+      "statusReason_text": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-status-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the reason the immunization event was not performed.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-status-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-status-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
+          }
+        },
+        "title": "Reason for current status",
+        "type": "string"
+      },
+      "subpotentReason": {
+        "binding_description": "The reason why a dose is considered to be subpotent.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason",
+        "binding_version": null,
+        "description": "text representation. Reason why a dose is considered to be subpotent.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "The reason why a dose is considered to be subpotent.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason"
+          }
+        },
+        "title": "Reason for being subpotent",
+        "type": "array"
+      },
+      "subpotentReason_coding": {
+        "binding_description": "The reason why a dose is considered to be subpotent.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Reason why a dose is considered to be subpotent.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "The reason why a dose is considered to be subpotent.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason"
+          }
+        },
+        "title": "Reason for being subpotent",
+        "type": "array"
+      },
+      "subpotentReason_text": {
+        "binding_description": "The reason why a dose is considered to be subpotent.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Reason why a dose is considered to be subpotent.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "The reason why a dose is considered to be subpotent.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason"
+          }
+        },
+        "title": "Reason for being subpotent",
+        "type": "array"
+      },
+      "supportingInformation": {
+        "backref": "supportingInformation_immunization",
+        "description": "[Text representation of Reference] Additional information that is relevant to the immunization (e.g. for a vaccine recipient who is pregnant, the gestational age of the fetus). The reason why a vaccine was given (e.g. occupation, underlying medical condition) should be conveyed in Immunization.reason, not as supporting information. The reason why a vaccine was not given (e.g. contraindication) should be conveyed in Immunization.statusReason, not as supporting information.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional information in support of the immunization",
+        "type": "array"
+      },
+      "vaccineCode": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/vaccine-code",
+        "binding_version": null,
+        "description": "text representation. Vaccine that was administered or was to be administered.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/vaccine-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/vaccine-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/vaccine-code"
+          }
+        },
+        "title": "Vaccine administered",
+        "type": "string"
+      },
+      "vaccineCode_coding": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/vaccine-code",
+        "binding_version": null,
+        "description": "[system#code representation.] Vaccine that was administered or was to be administered.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/vaccine-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/vaccine-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/vaccine-code"
+          }
+        },
+        "title": "Vaccine administered",
+        "type": "string"
+      },
+      "vaccineCode_text": {
+        "binding_description": "x",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/vaccine-code",
+        "binding_version": null,
+        "description": "[system#code representation.] Vaccine that was administered or was to be administered.",
+        "element_property": true,
+        "term": {
+          "description": "x",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/vaccine-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/vaccine-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/vaccine-code"
+          }
+        },
+        "title": "Vaccine administered",
+        "type": "string"
+      }
+    },
+    "title": "Immunization",
+    "type": "object"
+  },
+  "_definitions.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "UUID": {
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "term": {
+        "$ref": "_terms.yaml#/UUID"
+      },
+      "type": "string"
+    },
+    "data_bundle_state": {
+      "default": "submitted",
+      "description": "State of a data bundle.",
+      "enum": [
+        "submitted",
+        "validated",
+        "error",
+        "released",
+        "suppressed",
+        "redacted"
+      ]
+    },
+    "data_file_error_type": {
+      "enum": [
+        "file_size",
+        "file_format",
+        "md5sum"
+      ],
+      "term": {
+        "$ref": "_terms.yaml#/data_file_error_type"
+      }
+    },
+    "data_file_properties": {
+      "$ref": "#/ubiquitous_properties",
+      "error_type": {
+        "$ref": "#/data_file_error_type"
+      },
+      "file_format": {
+        "$ref": "#/file_format"
+      },
+      "file_name": {
+        "$ref": "#/file_name"
+      },
+      "file_size": {
+        "$ref": "#/file_size"
+      },
+      "file_state": {
+        "$ref": "#/file_state"
+      },
+      "ga4gh_drs_uri": {
+        "$ref": "#/ga4gh_drs_uri"
+      },
+      "md5sum": {
+        "$ref": "#/md5sum"
+      },
+      "object_id": {
+        "$ref": "#/object_id"
+      }
+    },
+    "datetime": {
+      "oneOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "term": {
+        "$ref": "_terms.yaml#/datetime"
+      }
+    },
+    "fhir_resource": {
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "$ref": "#/UUID"
+        },
+        "resource_type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "file_format": {
+      "term": {
+        "$ref": "_terms.yaml#/file_format"
+      },
+      "type": "string"
+    },
+    "file_name": {
+      "term": {
+        "$ref": "_terms.yaml#/file_name"
+      },
+      "type": "string"
+    },
+    "file_size": {
+      "term": {
+        "$ref": "_terms.yaml#/file_size"
+      },
+      "type": "integer"
+    },
+    "file_state": {
+      "default": "registered",
+      "enum": [
+        "registered",
+        "uploading",
+        "uploaded",
+        "validating",
+        "validated",
+        "submitted",
+        "processing",
+        "processed",
+        "released",
+        "error"
+      ],
+      "term": {
+        "$ref": "_terms.yaml#/file_state"
+      }
+    },
+    "foreign_key": {
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "$ref": "#/UUID"
+        },
+        "submitter_id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "foreign_key_project": {
+      "additionalProperties": true,
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "id": {
+          "$ref": "#/UUID"
+        }
+      },
+      "type": "object"
+    },
+    "ga4gh_drs_uri": {
+      "term": {
+        "$ref": "_terms.yaml#/ga4gh_drs_uri"
+      },
+      "type": "string"
+    },
+    "id": "_definitions",
+    "md5sum": {
+      "pattern": "^[a-f0-9]{32}$",
+      "term": {
+        "$ref": "_terms.yaml#/md5sum"
+      },
+      "type": "string"
+    },
+    "object_id": {
+      "description": "The GUID of the object in the index service.",
+      "type": "string"
+    },
+    "parent_uuids": {
+      "items": {
+        "$ref": "#/UUID"
+      },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "project_id": {
+      "term": {
+        "$ref": "_terms.yaml#/project_id"
+      },
+      "type": "string"
+    },
+    "qc_metrics_state": {
+      "enum": [
+        "FAIL",
+        "PASS",
+        "WARN"
+      ],
+      "term": {
+        "$ref": "_terms.yaml#/qc_metric_state"
+      }
+    },
+    "release_state": {
+      "default": "unreleased",
+      "description": "Release state of an entity.",
+      "enum": [
+        "unreleased",
+        "released",
+        "redacted"
+      ]
+    },
+    "state": {
+      "default": "validated",
+      "downloadable": [
+        "uploaded",
+        "md5summed",
+        "validating",
+        "validated",
+        "error",
+        "invalid",
+        "released"
+      ],
+      "oneOf": [
+        {
+          "enum": [
+            "uploading",
+            "uploaded",
+            "md5summing",
+            "md5summed",
+            "validating",
+            "error",
+            "invalid",
+            "suppressed",
+            "redacted",
+            "live"
+          ]
+        },
+        {
+          "enum": [
+            "validated",
+            "submitted",
+            "released"
+          ]
+        }
+      ],
+      "public": [
+        "live"
+      ],
+      "term": {
+        "$ref": "_terms.yaml#/state"
+      }
+    },
+    "to_many": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/foreign_key",
+            "minItems": 1
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/foreign_key"
+        }
+      ]
+    },
+    "to_many_project": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/foreign_key_project",
+            "minItems": 1
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/foreign_key_project"
+        }
+      ]
+    },
+    "to_one": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/foreign_key",
+            "maxItems": 1,
+            "minItems": 1
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/foreign_key"
+        }
+      ]
+    },
+    "to_one_project": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/foreign_key_project",
+            "maxItems": 1,
+            "minItems": 1
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/foreign_key_project"
+        }
+      ]
+    },
+    "ubiquitous_properties": {
+      "created_datetime": {
+        "$ref": "#/datetime"
+      },
+      "id": {
+        "$ref": "#/UUID",
+        "systemAlias": "node_id"
+      },
+      "project_id": {
+        "$ref": "#/project_id"
+      },
+      "state": {
+        "$ref": "#/state"
+      },
+      "submitter_id": {
+        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "type": [
+          "string"
+        ]
+      },
+      "type": {
+        "type": "string"
+      },
+      "updated_datetime": {
+        "$ref": "#/datetime"
+      }
+    },
+    "workflow_properties": {
+      "$ref": "#/ubiquitous_properties",
+      "workflow_end_datetime": {
+        "$ref": "#/datetime"
+      },
+      "workflow_link": {
+        "description": "Link to Github hash for the CWL workflow used.",
+        "type": "string"
+      },
+      "workflow_start_datetime": {
+        "$ref": "#/datetime"
+      },
+      "workflow_version": {
+        "description": "Major version for a GDC workflow.",
+        "type": "string"
+      }
+    }
+  },
+  "document_reference.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "data_file",
+    "description": "A reference to a document. A reference to a document of any kind for any purpose. While the term \u201cdocument\u201d implies a more narrow focus, for this resource this \"document\" encompasses *any* serialized object with a mime-type, it includes formal patient-centric documents (CDA), clinical notes, scanned paper, non-patient specific documents like policy text, as well as a photo, video, or audio recording acquired or used in healthcare.  The DocumentReference resource provides metadata about the document so that the document can be discovered and managed.  The actual content may be inline base64 encoded data or provided by direct reference. [See https://hl7.org/fhir/R5/DocumentReference.html]",
+    "id": "document_reference",
+    "links": [
+      {
+        "backref": "author_document_reference",
+        "label": "DocumentReference_author_Patient_author_document_reference",
+        "multiplicity": "many_to_many",
+        "name": "author_Patient",
+        "required": false,
+        "target_type": "patient"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "$ref": "_definitions.yaml#/data_file_properties",
+      "attester": {
+        "description": "[Text representation of DocumentReferenceAttester] A participant who has authenticated the accuracy of the document.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Attests to accuracy of the document",
+        "type": "array"
+      },
+      "auth_resource_path": {
+        "description": "Gen3 scaffolding",
+        "type": "string"
+      },
+      "author": {
+        "backref": "author_document_reference",
+        "description": "[Text representation of Reference] Identifies who is responsible for adding the information to the document.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Practitioner",
+          "PractitionerRole",
+          "Organization",
+          "Device",
+          "Patient",
+          "RelatedPerson",
+          "CareTeam"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Who and/or what authored the document",
+        "type": "array"
+      },
+      "basedOn": {
+        "backref": "basedOn_document_reference",
+        "description": "[Text representation of Reference] A procedure that is fulfilled in whole or in part by the creation of this media.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Appointment",
+          "AppointmentResponse",
+          "CarePlan",
+          "Claim",
+          "CommunicationRequest",
+          "Contract",
+          "CoverageEligibilityRequest",
+          "DeviceRequest",
+          "EnrollmentRequest",
+          "ImmunizationRecommendation",
+          "MedicationRequest",
+          "NutritionOrder",
+          "RequestOrchestration",
+          "ServiceRequest",
+          "SupplyRequest",
+          "VisionPrescription"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Procedure that caused this media to be created",
+        "type": "array"
+      },
+      "bodySite": {
+        "backref": "bodySite_document_reference",
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "text representation. The anatomic structures included in the document.",
+        "element_property": true,
+        "enum_reference_types": [
+          "BodyStructure"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Body part included",
+        "type": "array"
+      },
+      "bodySite_coding": {
+        "backref": "bodySite_document_reference",
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] The anatomic structures included in the document.",
+        "element_property": true,
+        "enum_reference_types": [
+          "BodyStructure"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Body part included",
+        "type": "array"
+      },
+      "bodySite_text": {
+        "backref": "bodySite_document_reference",
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] The anatomic structures included in the document.",
+        "element_property": true,
+        "enum_reference_types": [
+          "BodyStructure"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Body part included",
+        "type": "array"
+      },
+      "category": {
+        "binding_description": "High-level kind of document at a macro level.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/referenced-item-category",
+        "binding_version": null,
+        "description": "text representation. A categorization for the type of document referenced - helps for indexing and searching. This may be implied by or derived from the code specified in the DocumentReference.type.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "High-level kind of document at a macro level.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/referenced-item-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/referenced-item-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/referenced-item-category"
+          }
+        },
+        "title": "Categorization of document",
+        "type": "array"
+      },
+      "category_coding": {
+        "binding_description": "High-level kind of document at a macro level.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/referenced-item-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A categorization for the type of document referenced - helps for indexing and searching. This may be implied by or derived from the code specified in the DocumentReference.type.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "High-level kind of document at a macro level.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/referenced-item-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/referenced-item-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/referenced-item-category"
+          }
+        },
+        "title": "Categorization of document",
+        "type": "array"
+      },
+      "category_text": {
+        "binding_description": "High-level kind of document at a macro level.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/referenced-item-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A categorization for the type of document referenced - helps for indexing and searching. This may be implied by or derived from the code specified in the DocumentReference.type.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "High-level kind of document at a macro level.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/referenced-item-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/referenced-item-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/referenced-item-category"
+          }
+        },
+        "title": "Categorization of document",
+        "type": "array"
+      },
+      "content_attachment_contentType": {
+        "binding_description": "BCP 13 (RFCs 2045, 2046, 2047, 4288, 4289 and 2049)",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/mimetypes",
+        "binding_version": "5.0.0",
+        "description": "[Plucked from DocumentReference.content] Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.",
+        "element_property": true,
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "Mime type of the content, with charset etc.",
+        "type": "string"
+      },
+      "content_attachment_extension_md5": {
+        "description": "[Plucked from DocumentReference.content] Value of extension",
+        "type": "string"
+      },
+      "content_attachment_size": {
+        "description": "[Plucked from DocumentReference.content] The number of bytes of data that make up this attachment (before base64 encoding, if that is done).",
+        "element_property": true,
+        "title": "Number of bytes of content (if url provided)",
+        "type": "integer"
+      },
+      "content_attachment_url": {
+        "description": "[Plucked from DocumentReference.content] A location where the data can be accessed.",
+        "element_property": true,
+        "format": "uri",
+        "maxLength": 65536,
+        "minLength": 1,
+        "title": "Uri where the data can be found",
+        "type": "string"
+      },
+      "context": {
+        "backref": "context_document_reference",
+        "description": "[Text representation of Reference] Describes the clinical encounter or type of care that the document content is associated with.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Appointment",
+          "Encounter",
+          "EpisodeOfCare"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Context of the document content",
+        "type": "array"
+      },
+      "custodian": {
+        "backref": "custodian_document_reference",
+        "description": "[Text representation of Reference] Identifies the organization or group who is responsible for ongoing maintenance of and access to the document.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "Organization which maintains the document",
+        "type": "string"
+      },
+      "data_category": {
+        "term": {
+          "$ref": "_terms.yaml#/data_category"
+        },
+        "type": "string"
+      },
+      "data_format": {
+        "term": {
+          "$ref": "_terms.yaml#/data_format"
+        },
+        "type": "string"
+      },
+      "data_type": {
+        "term": {
+          "$ref": "_terms.yaml#/data_type"
+        },
+        "type": "string"
+      },
+      "date": {
+        "description": "When the document reference was created.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "When this document reference was created",
+        "type": "string"
+      },
+      "description": {
+        "description": "Human-readable description of the source document.",
+        "element_property": true,
+        "pattern": "\\s*(\\S|\\s)*",
+        "title": "Human-readable description",
+        "type": "string"
+      },
+      "docStatus": {
+        "binding_description": "Status of the underlying document.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/composition-status",
+        "binding_version": "5.0.0",
+        "description": "The status of the underlying document.",
+        "element_property": true,
+        "enum_values": [
+          "registered",
+          "partial",
+          "preliminary",
+          "final",
+          "amended",
+          "corrected",
+          "appended",
+          "cancelled",
+          "entered-in-error",
+          "deprecated",
+          "unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "registered | partial | preliminary | final | amended | corrected | appended | cancelled | entered-in-error | deprecated | unknown",
+        "type": "string"
+      },
+      "event": {
+        "backref": "event_document_reference",
+        "binding_description": "This list of codes represents the main clinical acts being documented.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-ActCode",
+        "binding_version": null,
+        "description": "text representation. This list of codes represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the type Code, such as a \"History and Physical Report\" in which the procedure being documented is necessarily a \"History and Physical\" act.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "This list of codes represents the main clinical acts being documented.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-ActCode",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v3-ActCode",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-ActCode"
+          }
+        },
+        "title": "Main clinical acts documented",
+        "type": "array"
+      },
+      "event_coding": {
+        "backref": "event_document_reference",
+        "binding_description": "This list of codes represents the main clinical acts being documented.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-ActCode",
+        "binding_version": null,
+        "description": "[system#code representation.] This list of codes represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the type Code, such as a \"History and Physical Report\" in which the procedure being documented is necessarily a \"History and Physical\" act.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "This list of codes represents the main clinical acts being documented.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-ActCode",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v3-ActCode",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-ActCode"
+          }
+        },
+        "title": "Main clinical acts documented",
+        "type": "array"
+      },
+      "event_text": {
+        "backref": "event_document_reference",
+        "binding_description": "This list of codes represents the main clinical acts being documented.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-ActCode",
+        "binding_version": null,
+        "description": "[system#code representation.] This list of codes represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the type Code, such as a \"History and Physical Report\" in which the procedure being documented is necessarily a \"History and Physical\" act.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "This list of codes represents the main clinical acts being documented.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-ActCode",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v3-ActCode",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-ActCode"
+          }
+        },
+        "title": "Main clinical acts documented",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "facilityType": {
+        "binding_description": "XDS Facility Type.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/c80-facilitycodes",
+        "binding_version": null,
+        "description": "text representation. The kind of facility where the patient was seen.",
+        "element_property": true,
+        "term": {
+          "description": "XDS Facility Type.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/c80-facilitycodes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/c80-facilitycodes",
+            "term_url": "http://hl7.org/fhir/ValueSet/c80-facilitycodes"
+          }
+        },
+        "title": "Kind of facility where patient was seen",
+        "type": "string"
+      },
+      "facilityType_coding": {
+        "binding_description": "XDS Facility Type.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/c80-facilitycodes",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind of facility where the patient was seen.",
+        "element_property": true,
+        "term": {
+          "description": "XDS Facility Type.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/c80-facilitycodes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/c80-facilitycodes",
+            "term_url": "http://hl7.org/fhir/ValueSet/c80-facilitycodes"
+          }
+        },
+        "title": "Kind of facility where patient was seen",
+        "type": "string"
+      },
+      "facilityType_text": {
+        "binding_description": "XDS Facility Type.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/c80-facilitycodes",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind of facility where the patient was seen.",
+        "element_property": true,
+        "term": {
+          "description": "XDS Facility Type.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/c80-facilitycodes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/c80-facilitycodes",
+            "term_url": "http://hl7.org/fhir/ValueSet/c80-facilitycodes"
+          }
+        },
+        "title": "Kind of facility where patient was seen",
+        "type": "string"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Other business identifiers associated with the document, including version independent identifiers.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifiers for the document",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Other business identifiers associated with the document, including version independent identifiers.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifiers for the document",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Other business identifiers associated with the document, including version independent identifiers.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifiers for the document",
+        "type": "array"
+      },
+      "modality": {
+        "binding_description": "Type of acquired data in the instance.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html",
+        "binding_version": null,
+        "description": "text representation. Imaging modality used. This may include both acquisition and non-acquisition modalities.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Type of acquired data in the instance.",
+          "termDef": {
+            "cde_id": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html",
+            "term_url": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html"
+          }
+        },
+        "title": "Imaging modality used",
+        "type": "array"
+      },
+      "modality_coding": {
+        "binding_description": "Type of acquired data in the instance.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html",
+        "binding_version": null,
+        "description": "[system#code representation.] Imaging modality used. This may include both acquisition and non-acquisition modalities.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Type of acquired data in the instance.",
+          "termDef": {
+            "cde_id": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html",
+            "term_url": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html"
+          }
+        },
+        "title": "Imaging modality used",
+        "type": "array"
+      },
+      "modality_text": {
+        "binding_description": "Type of acquired data in the instance.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html",
+        "binding_version": null,
+        "description": "[system#code representation.] Imaging modality used. This may include both acquisition and non-acquisition modalities.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Type of acquired data in the instance.",
+          "termDef": {
+            "cde_id": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html",
+            "term_url": "http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_33.html"
+          }
+        },
+        "title": "Imaging modality used",
+        "type": "array"
+      },
+      "patient_id": {
+        "description": "Denormalized patient id",
+        "type": "string"
+      },
+      "period": {
+        "description": "[Text representation of Period] The time period over which the service that is described by the document was provided.",
+        "element_property": true,
+        "title": "Time of service that is being documented",
+        "type": "string"
+      },
+      "practiceSetting": {
+        "binding_description": "Additional details about where the content was created (e.g. clinical specialty).",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+        "binding_version": null,
+        "description": "text representation. This property may convey specifics about the practice setting where the content was created, often reflecting the clinical specialty.",
+        "element_property": true,
+        "term": {
+          "description": "Additional details about where the content was created (e.g. clinical specialty).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
+          }
+        },
+        "title": "Additional details about where the content was created (e.g. clinical specialty)",
+        "type": "string"
+      },
+      "practiceSetting_coding": {
+        "binding_description": "Additional details about where the content was created (e.g. clinical specialty).",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] This property may convey specifics about the practice setting where the content was created, often reflecting the clinical specialty.",
+        "element_property": true,
+        "term": {
+          "description": "Additional details about where the content was created (e.g. clinical specialty).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
+          }
+        },
+        "title": "Additional details about where the content was created (e.g. clinical specialty)",
+        "type": "string"
+      },
+      "practiceSetting_text": {
+        "binding_description": "Additional details about where the content was created (e.g. clinical specialty).",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] This property may convey specifics about the practice setting where the content was created, often reflecting the clinical specialty.",
+        "element_property": true,
+        "term": {
+          "description": "Additional details about where the content was created (e.g. clinical specialty).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
+          }
+        },
+        "title": "Additional details about where the content was created (e.g. clinical specialty)",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "relatesTo": {
+        "description": "[Text representation of DocumentReferenceRelatesTo] Relationships that this document has with other document references that already exist.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Relationships to other documents",
+        "type": "array"
+      },
+      "resourceType": {
+        "const": "DocumentReference",
+        "default": "DocumentReference",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "securityLabel": {
+        "binding_description": "Example Security Labels from the Healthcare Privacy and Security Classification System.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/security-label-examples",
+        "binding_version": null,
+        "description": "text representation. A set of Security-Tag codes specifying the level of privacy/security of the Document found at DocumentReference.content.attachment.url. Note that DocumentReference.meta.security contains the security labels of the data elements in DocumentReference, while DocumentReference.securityLabel contains the security labels for the document the reference refers to. The distinction recognizes that the document may contain sensitive information, while the DocumentReference is metadata about the document and thus might not be as sensitive as the document. For example: a psychotherapy episode may contain highly sensitive information, while the metadata may simply indicate that some episode happened.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Example Security Labels from the Healthcare Privacy and Security Classification System.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/security-label-examples",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/security-label-examples",
+            "term_url": "http://hl7.org/fhir/ValueSet/security-label-examples"
+          }
+        },
+        "title": "Document security-tags",
+        "type": "array"
+      },
+      "securityLabel_coding": {
+        "binding_description": "Example Security Labels from the Healthcare Privacy and Security Classification System.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/security-label-examples",
+        "binding_version": null,
+        "description": "[system#code representation.] A set of Security-Tag codes specifying the level of privacy/security of the Document found at DocumentReference.content.attachment.url. Note that DocumentReference.meta.security contains the security labels of the data elements in DocumentReference, while DocumentReference.securityLabel contains the security labels for the document the reference refers to. The distinction recognizes that the document may contain sensitive information, while the DocumentReference is metadata about the document and thus might not be as sensitive as the document. For example: a psychotherapy episode may contain highly sensitive information, while the metadata may simply indicate that some episode happened.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Example Security Labels from the Healthcare Privacy and Security Classification System.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/security-label-examples",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/security-label-examples",
+            "term_url": "http://hl7.org/fhir/ValueSet/security-label-examples"
+          }
+        },
+        "title": "Document security-tags",
+        "type": "array"
+      },
+      "securityLabel_text": {
+        "binding_description": "Example Security Labels from the Healthcare Privacy and Security Classification System.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/security-label-examples",
+        "binding_version": null,
+        "description": "[system#code representation.] A set of Security-Tag codes specifying the level of privacy/security of the Document found at DocumentReference.content.attachment.url. Note that DocumentReference.meta.security contains the security labels of the data elements in DocumentReference, while DocumentReference.securityLabel contains the security labels for the document the reference refers to. The distinction recognizes that the document may contain sensitive information, while the DocumentReference is metadata about the document and thus might not be as sensitive as the document. For example: a psychotherapy episode may contain highly sensitive information, while the metadata may simply indicate that some episode happened.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Example Security Labels from the Healthcare Privacy and Security Classification System.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/security-label-examples",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/security-label-examples",
+            "term_url": "http://hl7.org/fhir/ValueSet/security-label-examples"
+          }
+        },
+        "title": "Document security-tags",
+        "type": "array"
+      },
+      "status": {
+        "binding_description": "The status of the document reference.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/document-reference-status",
+        "binding_version": "5.0.0",
+        "description": "The status of this document reference.",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "current",
+          "superseded",
+          "entered-in-error"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "current | superseded | entered-in-error",
+        "type": "string"
+      },
+      "subject": {
+        "backref": "document_reference",
+        "description": "[Text representation of Reference] Who or what the document is about. The document can be about a person, (patient or healthcare practitioner), a device (e.g. a machine) or even a group of subjects (such as a document about a herd of farm animals, or a set of patients that share a common exposure).",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "title": "Who/what is the subject of the document",
+        "type": "string"
+      },
+      "type": {
+        "binding_description": "Precise type of clinical document.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/doc-typecodes",
+        "binding_version": null,
+        "description": "text representation. Specifies the particular kind of document referenced  (e.g. History and Physical, Discharge Summary, Progress Note). This usually equates to the purpose of making the document referenced.",
+        "element_property": true,
+        "term": {
+          "description": "Precise type of clinical document.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/doc-typecodes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/doc-typecodes",
+            "term_url": "http://hl7.org/fhir/ValueSet/doc-typecodes"
+          }
+        },
+        "title": "Kind of document (LOINC if possible)",
+        "type": "string"
+      },
+      "type_coding": {
+        "binding_description": "Precise type of clinical document.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/doc-typecodes",
+        "binding_version": null,
+        "description": "[system#code representation.] Specifies the particular kind of document referenced  (e.g. History and Physical, Discharge Summary, Progress Note). This usually equates to the purpose of making the document referenced.",
+        "element_property": true,
+        "term": {
+          "description": "Precise type of clinical document.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/doc-typecodes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/doc-typecodes",
+            "term_url": "http://hl7.org/fhir/ValueSet/doc-typecodes"
+          }
+        },
+        "title": "Kind of document (LOINC if possible)",
+        "type": "string"
+      },
+      "type_text": {
+        "binding_description": "Precise type of clinical document.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/doc-typecodes",
+        "binding_version": null,
+        "description": "[system#code representation.] Specifies the particular kind of document referenced  (e.g. History and Physical, Discharge Summary, Progress Note). This usually equates to the purpose of making the document referenced.",
+        "element_property": true,
+        "term": {
+          "description": "Precise type of clinical document.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/doc-typecodes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/doc-typecodes",
+            "term_url": "http://hl7.org/fhir/ValueSet/doc-typecodes"
+          }
+        },
+        "title": "Kind of document (LOINC if possible)",
+        "type": "string"
+      },
+      "version": {
+        "description": "An explicitly assigned identifer of a variation of the content in the DocumentReference",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "An explicitly assigned identifer of a variation of the content in the DocumentReference",
+        "type": "string"
+      }
+    },
+    "title": "DocumentReference",
+    "type": "object"
+  },
+  "_settings.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "enable_case_cache": false,
+    "_dict_commit": "520a25999fd183f6c5b7ddef2980f3e839517da5",
+    "_dict_version": "0.2.1-9-g520a259"
+  },
+  "task.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Analysis",
+    "description": "A task to be performed. [See https://hl7.org/fhir/R5/Task.html]",
+    "id": "task",
+    "links": [
+      {
+        "backref": "task",
+        "label": "Task_encounter_Encounter_task",
+        "multiplicity": "many_to_many",
+        "name": "encounter",
+        "required": false,
+        "target_type": "encounter"
+      },
+      {
+        "backref": "task",
+        "label": "Task_location_Location_task",
+        "multiplicity": "many_to_many",
+        "name": "location",
+        "required": false,
+        "target_type": "location"
+      },
+      {
+        "backref": "owner_task",
+        "label": "Task_owner_Practitioner_owner_task",
+        "multiplicity": "many_to_many",
+        "name": "owner_Practitioner",
+        "required": false,
+        "target_type": "practitioner"
+      },
+      {
+        "backref": "owner_task",
+        "label": "Task_owner_PractitionerRole_owner_task",
+        "multiplicity": "many_to_many",
+        "name": "owner_PractitionerRole",
+        "required": false,
+        "target_type": "practitioner_role"
+      },
+      {
+        "backref": "owner_task",
+        "label": "Task_owner_Organization_owner_task",
+        "multiplicity": "many_to_many",
+        "name": "owner_Organization",
+        "required": false,
+        "target_type": "organization"
+      },
+      {
+        "backref": "owner_task",
+        "label": "Task_owner_Patient_owner_task",
+        "multiplicity": "many_to_many",
+        "name": "owner_Patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "partOf_task",
+        "label": "Task_partOf_Task_partOf_task",
+        "multiplicity": "many_to_many",
+        "name": "partOf",
+        "required": false,
+        "target_type": "task"
+      },
+      {
+        "backref": "task",
+        "label": "Task_specimen_Specimen_task",
+        "multiplicity": "many_to_many",
+        "name": "specimen",
+        "required": false,
+        "target_type": "specimen"
+      },
+      {
+        "backref": "task",
+        "label": "Task_document_reference_DocumentReference_task",
+        "multiplicity": "many_to_many",
+        "name": "document_reference",
+        "required": false,
+        "target_type": "document_reference"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "authoredOn": {
+        "description": "The date and time this task was created.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "Task Creation Date",
+        "type": "string"
+      },
+      "basedOn": {
+        "backref": "basedOn_task",
+        "description": "[Text representation of Reference] BasedOn refers to a higher-level authorization that triggered the creation of the task.  It references a \"request\" resource such as a ServiceRequest, MedicationRequest, CarePlan, etc. which is distinct from the \"request\" resource the task is seeking to fulfill.  This latter resource is referenced by focus.  For example, based on a CarePlan (= basedOn), a task is created to fulfill a ServiceRequest ( = focus ) to collect a specimen from a patient.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Request fulfilled by this task",
+        "type": "array"
+      },
+      "businessStatus": {
+        "description": "text representation. Contains business-specific nuances of the business state.",
+        "element_property": true,
+        "title": "E.g. \"Specimen collected\", \"IV prepped\"",
+        "type": "string"
+      },
+      "businessStatus_coding": {
+        "description": "[system#code representation.] Contains business-specific nuances of the business state.",
+        "element_property": true,
+        "title": "E.g. \"Specimen collected\", \"IV prepped\"",
+        "type": "string"
+      },
+      "businessStatus_text": {
+        "description": "[system#code representation.] Contains business-specific nuances of the business state.",
+        "element_property": true,
+        "title": "E.g. \"Specimen collected\", \"IV prepped\"",
+        "type": "string"
+      },
+      "code": {
+        "binding_description": "Codes to identify what the task involves.  These will typically be specific to a particular workflow.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/task-code",
+        "binding_version": null,
+        "description": "text representation. A name or code (or both) briefly describing what the task involves.",
+        "element_property": true,
+        "term": {
+          "description": "Codes to identify what the task involves.  These will typically be specific to a particular workflow.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/task-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/task-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/task-code"
+          }
+        },
+        "title": "Task Type",
+        "type": "string"
+      },
+      "code_coding": {
+        "binding_description": "Codes to identify what the task involves.  These will typically be specific to a particular workflow.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/task-code",
+        "binding_version": null,
+        "description": "[system#code representation.] A name or code (or both) briefly describing what the task involves.",
+        "element_property": true,
+        "term": {
+          "description": "Codes to identify what the task involves.  These will typically be specific to a particular workflow.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/task-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/task-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/task-code"
+          }
+        },
+        "title": "Task Type",
+        "type": "string"
+      },
+      "code_text": {
+        "binding_description": "Codes to identify what the task involves.  These will typically be specific to a particular workflow.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/task-code",
+        "binding_version": null,
+        "description": "[system#code representation.] A name or code (or both) briefly describing what the task involves.",
+        "element_property": true,
+        "term": {
+          "description": "Codes to identify what the task involves.  These will typically be specific to a particular workflow.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/task-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/task-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/task-code"
+          }
+        },
+        "title": "Task Type",
+        "type": "string"
+      },
+      "description": {
+        "description": "A free-text description of what is to be performed.",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Human-readable explanation of task",
+        "type": "string"
+      },
+      "doNotPerform": {
+        "description": "If true indicates that the Task is asking for the specified action to *not* occur.",
+        "element_property": true,
+        "title": "True if Task is prohibiting action",
+        "type": "boolean"
+      },
+      "document_reference": {
+        "backref": "task",
+        "description": "[Text representation of Reference] The output from this task.  Used to generate link.",
+        "enum_reference_types": [
+          "DocumentReference"
+        ],
+        "title": "The output from this task.",
+        "type": "string"
+      },
+      "encounter": {
+        "backref": "task",
+        "description": "[Text representation of Reference] The healthcare event  (e.g. a patient and healthcare provider interaction) during which this task was created.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Encounter"
+        ],
+        "title": "Healthcare event during which this task originated",
+        "type": "string"
+      },
+      "executionPeriod": {
+        "description": "[Text representation of Period] Identifies the time action was first taken against the task (start) and/or the time final action was taken against the task prior to marking it as completed (end).",
+        "element_property": true,
+        "title": "Start and end time of execution",
+        "type": "string"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "focus": {
+        "backref": "focus_task",
+        "description": "[Text representation of Reference] The request being fulfilled or the resource being manipulated (changed, suspended, etc.) by this task.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "title": "What task is acting on",
+        "type": "string"
+      },
+      "for_fhir": {
+        "backref": "for_task",
+        "description": "[Text representation of Reference] [Reserved word `for` renamed to `for_fhir`] The entity who benefits from the performance of the service specified in the task (e.g., the patient).",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "title": "Beneficiary of the Task",
+        "type": "string"
+      },
+      "groupIdentifier": {
+        "description": "[Text representation of Identifier] A shared identifier common to multiple independent Task and Request instances that were activated/authorized more or less simultaneously by a single author.  The presence of the same identifier on each request ties those requests together and may have business ramifications in terms of reporting of results, billing, etc.  E.g. a requisition number shared by a set of lab tests ordered together, or a prescription number shared by all meds ordered at one time.",
+        "element_property": true,
+        "title": "Requisition or grouper id",
+        "type": "string"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "The business identifier for this task.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Task Instance Identifier",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] The business identifier for this task.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Task Instance Identifier",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] The business identifier for this task.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Task Instance Identifier",
+        "type": "array"
+      },
+      "input_valueReference": {
+        "backref": "task_input",
+        "description": "[Text representation of Reference] [Plucked from Task.input] The value of the input parameter as a basic type.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": true,
+        "title": "Content to use in performing the task",
+        "type": "string"
+      },
+      "instantiatesCanonical": {
+        "description": "The URL pointing to a *FHIR*-defined protocol, guideline, orderset or other definition that is adhered to in whole or in part by this Task.",
+        "element_property": true,
+        "enum_reference_types": [
+          "ActivityDefinition"
+        ],
+        "pattern": "\\S*",
+        "title": "Formal definition of task",
+        "type": "string"
+      },
+      "instantiatesUri": {
+        "description": "The URL pointing to an *externally* maintained  protocol, guideline, orderset or other definition that is adhered to in whole or in part by this Task.",
+        "element_property": true,
+        "pattern": "\\S*",
+        "title": "Formal definition of task",
+        "type": "string"
+      },
+      "insurance": {
+        "backref": "insurance_task",
+        "description": "[Text representation of Reference] Insurance plans, coverage extensions, pre-authorizations and/or pre-determinations that may be relevant to the Task.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Coverage",
+          "ClaimResponse"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Associated insurance coverage",
+        "type": "array"
+      },
+      "intent": {
+        "binding_description": "Distinguishes whether the task is a proposal, plan or full order.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/task-intent",
+        "binding_version": "5.0.0",
+        "description": "Indicates the \"level\" of actionability associated with the Task, i.e. i+R[9]Cs this a proposed task, a planned task, an actionable task, etc.",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "unknown",
+          "proposal",
+          "plan",
+          "order",
+          "original-order",
+          "reflex-order",
+          "filler-order",
+          "instance-order",
+          "option"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "unknown | proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option",
+        "type": "string"
+      },
+      "lastModified": {
+        "description": "The date and time of last modification to this task.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "Task Last Modified Date",
+        "type": "string"
+      },
+      "location": {
+        "backref": "task",
+        "description": "[Text representation of Reference] Principal physical location where this task is performed.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Location"
+        ],
+        "title": "Where task occurs",
+        "type": "string"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] Free-text information captured about the task as it progresses.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Comments made about the task",
+        "type": "array"
+      },
+      "output_valueReference": {
+        "backref": "task_output",
+        "description": "[Text representation of Reference] [Plucked from Task.output] The value of the Output parameter as a basic type.",
+        "element_property": true,
+        "one_of_many": "value",
+        "one_of_many_required": true,
+        "title": "Result of output",
+        "type": "string"
+      },
+      "owner": {
+        "backref": "owner_task",
+        "description": "[Text representation of Reference] Party responsible for managing task execution.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Practitioner",
+          "PractitionerRole",
+          "Organization",
+          "CareTeam",
+          "Patient",
+          "RelatedPerson"
+        ],
+        "title": "Responsible individual",
+        "type": "string"
+      },
+      "partOf": {
+        "backref": "partOf_task",
+        "description": "[Text representation of Reference] Task that this particular task is part of.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Task"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Composite task",
+        "type": "array"
+      },
+      "performer": {
+        "description": "[Text representation of TaskPerformer] The entity who performed the requested task.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Who or what performed the task",
+        "type": "array"
+      },
+      "priority": {
+        "binding_description": "The priority of a task (may affect service level applied to the task).",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/request-priority",
+        "binding_version": "5.0.0",
+        "description": "Indicates how quickly the Task should be addressed with respect to other requests.",
+        "element_property": true,
+        "enum_values": [
+          "routine",
+          "urgent",
+          "asap",
+          "stat"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "routine | urgent | asap | stat",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "reason": {
+        "backref": "reason_task",
+        "description": "text representation. A description, code, or reference indicating why this task needs to be performed.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Why task is needed",
+        "type": "array"
+      },
+      "reason_coding": {
+        "backref": "reason_task",
+        "description": "[system#code representation.] A description, code, or reference indicating why this task needs to be performed.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Why task is needed",
+        "type": "array"
+      },
+      "reason_text": {
+        "backref": "reason_task",
+        "description": "[system#code representation.] A description, code, or reference indicating why this task needs to be performed.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Why task is needed",
+        "type": "array"
+      },
+      "relevantHistory": {
+        "backref": "relevantHistory_task",
+        "description": "[Text representation of Reference] Links to Provenance records for past versions of this Task that identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the task.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Provenance"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Key events in history of the Task",
+        "type": "array"
+      },
+      "requestedPerformer": {
+        "backref": "requestedPerformer_task",
+        "binding_description": "The type(s) of task performers allowed.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/performer-role",
+        "binding_version": null,
+        "description": "text representation. The kind of participant or specific participant that should perform the task.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Practitioner",
+          "PractitionerRole",
+          "Organization",
+          "CareTeam",
+          "HealthcareService",
+          "Patient",
+          "Device",
+          "RelatedPerson"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "The type(s) of task performers allowed.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/performer-role",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/performer-role",
+            "term_url": "http://hl7.org/fhir/ValueSet/performer-role"
+          }
+        },
+        "title": "Who should perform Task",
+        "type": "array"
+      },
+      "requestedPerformer_coding": {
+        "backref": "requestedPerformer_task",
+        "binding_description": "The type(s) of task performers allowed.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/performer-role",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind of participant or specific participant that should perform the task.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Practitioner",
+          "PractitionerRole",
+          "Organization",
+          "CareTeam",
+          "HealthcareService",
+          "Patient",
+          "Device",
+          "RelatedPerson"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "The type(s) of task performers allowed.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/performer-role",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/performer-role",
+            "term_url": "http://hl7.org/fhir/ValueSet/performer-role"
+          }
+        },
+        "title": "Who should perform Task",
+        "type": "array"
+      },
+      "requestedPerformer_text": {
+        "backref": "requestedPerformer_task",
+        "binding_description": "The type(s) of task performers allowed.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/performer-role",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind of participant or specific participant that should perform the task.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Practitioner",
+          "PractitionerRole",
+          "Organization",
+          "CareTeam",
+          "HealthcareService",
+          "Patient",
+          "Device",
+          "RelatedPerson"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "The type(s) of task performers allowed.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/performer-role",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/performer-role",
+            "term_url": "http://hl7.org/fhir/ValueSet/performer-role"
+          }
+        },
+        "title": "Who should perform Task",
+        "type": "array"
+      },
+      "requestedPeriod": {
+        "description": "[Text representation of Period] Indicates the start and/or end of the period of time when completion of the task is desired to take place.",
+        "element_property": true,
+        "title": "When the task should be performed",
+        "type": "string"
+      },
+      "requester": {
+        "backref": "requester_task",
+        "description": "[Text representation of Reference] The creator of the task.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Device",
+          "Organization",
+          "Patient",
+          "Practitioner",
+          "PractitionerRole",
+          "RelatedPerson"
+        ],
+        "title": "Who is asking for task to be done",
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "Task",
+        "default": "Task",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "restriction": {
+        "description": "[Text representation of TaskRestriction] If the Task.focus is a request resource and the task is seeking fulfillment (i.e. is asking for the request to be actioned), this element identifies any limitations on what parts of the referenced request should be actioned.",
+        "element_property": true,
+        "title": "Constraints on fulfillment tasks",
+        "type": "string"
+      },
+      "specimen": {
+        "backref": "task",
+        "description": "[Text representation of Reference] The specimen input to this task.  Used to generate link.",
+        "enum_reference_types": [
+          "Specimen"
+        ],
+        "title": "The specimen input to this task.",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "The current status of the task.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/task-status",
+        "binding_version": "5.0.0",
+        "description": "The current status of the task.",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "draft",
+          "requested",
+          "received",
+          "accepted",
+          "+"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "draft | requested | received | accepted | +",
+        "type": "string"
+      },
+      "statusReason": {
+        "backref": "task",
+        "binding_description": "Codes to identify the reason for current status.  These will typically be specific to a particular workflow.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/task-status-reason",
+        "binding_version": null,
+        "description": "text representation. An explanation as to why this task is held, failed, was refused, etc.",
+        "element_property": true,
+        "term": {
+          "description": "Codes to identify the reason for current status.  These will typically be specific to a particular workflow.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/task-status-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/task-status-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/task-status-reason"
+          }
+        },
+        "title": "Reason for current status",
+        "type": "string"
+      },
+      "statusReason_coding": {
+        "backref": "task",
+        "binding_description": "Codes to identify the reason for current status.  These will typically be specific to a particular workflow.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/task-status-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] An explanation as to why this task is held, failed, was refused, etc.",
+        "element_property": true,
+        "term": {
+          "description": "Codes to identify the reason for current status.  These will typically be specific to a particular workflow.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/task-status-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/task-status-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/task-status-reason"
+          }
+        },
+        "title": "Reason for current status",
+        "type": "string"
+      },
+      "statusReason_text": {
+        "backref": "task",
+        "binding_description": "Codes to identify the reason for current status.  These will typically be specific to a particular workflow.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/task-status-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] An explanation as to why this task is held, failed, was refused, etc.",
+        "element_property": true,
+        "term": {
+          "description": "Codes to identify the reason for current status.  These will typically be specific to a particular workflow.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/task-status-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/task-status-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/task-status-reason"
+          }
+        },
+        "title": "Reason for current status",
+        "type": "string"
+      }
+    },
+    "title": "Task",
+    "type": "object"
+  },
+  "condition.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "Detailed information about conditions, problems or diagnoses. A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern. [See https://hl7.org/fhir/R5/Condition.html]",
+    "id": "condition",
+    "links": [
+      {
+        "backref": "condition",
+        "label": "Condition_subject_Patient_condition",
+        "multiplicity": "many_to_many",
+        "name": "subject_Patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "condition",
+        "label": "Condition_encounter_Encounter_condition",
+        "multiplicity": "many_to_many",
+        "name": "encounter",
+        "required": false,
+        "target_type": "encounter"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "abatementAge": {
+        "description": "[Text representation of Age] The date or estimated date that the condition resolved or went into remission. This is called \"abatement\" because of the many overloaded connotations associated with \"remission\" or \"resolution\" - Some conditions, such as chronic conditions, are never really resolved, but they can abate.",
+        "element_property": true,
+        "one_of_many": "abatement",
+        "one_of_many_required": false,
+        "title": "When in resolution/remission",
+        "type": "string"
+      },
+      "abatementDateTime": {
+        "description": "The date or estimated date that the condition resolved or went into remission. This is called \"abatement\" because of the many overloaded connotations associated with \"remission\" or \"resolution\" - Some conditions, such as chronic conditions, are never really resolved, but they can abate.",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "abatement",
+        "one_of_many_required": false,
+        "title": "When in resolution/remission",
+        "type": "string"
+      },
+      "abatementPeriod": {
+        "description": "[Text representation of Period] The date or estimated date that the condition resolved or went into remission. This is called \"abatement\" because of the many overloaded connotations associated with \"remission\" or \"resolution\" - Some conditions, such as chronic conditions, are never really resolved, but they can abate.",
+        "element_property": true,
+        "one_of_many": "abatement",
+        "one_of_many_required": false,
+        "title": "When in resolution/remission",
+        "type": "string"
+      },
+      "abatementRange": {
+        "description": "[Text representation of Range] The date or estimated date that the condition resolved or went into remission. This is called \"abatement\" because of the many overloaded connotations associated with \"remission\" or \"resolution\" - Some conditions, such as chronic conditions, are never really resolved, but they can abate.",
+        "element_property": true,
+        "one_of_many": "abatement",
+        "one_of_many_required": false,
+        "title": "When in resolution/remission",
+        "type": "string"
+      },
+      "abatementString": {
+        "description": "The date or estimated date that the condition resolved or went into remission. This is called \"abatement\" because of the many overloaded connotations associated with \"remission\" or \"resolution\" - Some conditions, such as chronic conditions, are never really resolved, but they can abate.",
+        "element_property": true,
+        "one_of_many": "abatement",
+        "one_of_many_required": false,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "When in resolution/remission",
+        "type": "string"
+      },
+      "bodySite": {
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "text representation. The anatomical location where this condition manifests itself.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Anatomical location, if relevant",
+        "type": "array"
+      },
+      "bodySite_coding": {
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] The anatomical location where this condition manifests itself.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Anatomical location, if relevant",
+        "type": "array"
+      },
+      "bodySite_text": {
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] The anatomical location where this condition manifests itself.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Anatomical location, if relevant",
+        "type": "array"
+      },
+      "category": {
+        "binding_description": "A category assigned to the condition.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-category",
+        "binding_version": null,
+        "description": "text representation. A category assigned to the condition.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A category assigned to the condition.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/condition-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-category"
+          }
+        },
+        "title": "problem-list-item | encounter-diagnosis",
+        "type": "array"
+      },
+      "category_coding": {
+        "binding_description": "A category assigned to the condition.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A category assigned to the condition.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A category assigned to the condition.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/condition-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-category"
+          }
+        },
+        "title": "problem-list-item | encounter-diagnosis",
+        "type": "array"
+      },
+      "category_text": {
+        "binding_description": "A category assigned to the condition.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A category assigned to the condition.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A category assigned to the condition.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/condition-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-category"
+          }
+        },
+        "title": "problem-list-item | encounter-diagnosis",
+        "type": "array"
+      },
+      "clinicalStatus": {
+        "binding_description": "The clinical status of the condition or diagnosis.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-clinical",
+        "binding_version": "5.0.0",
+        "description": "text representation. The clinical status of the condition.",
+        "element_property": true,
+        "term": {
+          "description": "The clinical status of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-clinical",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/condition-clinical",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-clinical"
+          }
+        },
+        "title": "active | recurrence | relapse | inactive | remission | resolved | unknown",
+        "type": "string"
+      },
+      "clinicalStatus_coding": {
+        "binding_description": "The clinical status of the condition or diagnosis.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-clinical",
+        "binding_version": "5.0.0",
+        "description": "[system#code representation.] The clinical status of the condition.",
+        "element_property": true,
+        "term": {
+          "description": "The clinical status of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-clinical",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/condition-clinical",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-clinical"
+          }
+        },
+        "title": "active | recurrence | relapse | inactive | remission | resolved | unknown",
+        "type": "string"
+      },
+      "clinicalStatus_text": {
+        "binding_description": "The clinical status of the condition or diagnosis.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-clinical",
+        "binding_version": "5.0.0",
+        "description": "[system#code representation.] The clinical status of the condition.",
+        "element_property": true,
+        "term": {
+          "description": "The clinical status of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-clinical",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/condition-clinical",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-clinical"
+          }
+        },
+        "title": "active | recurrence | relapse | inactive | remission | resolved | unknown",
+        "type": "string"
+      },
+      "code": {
+        "binding_description": "Identification of the condition or diagnosis.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-code",
+        "binding_version": null,
+        "description": "text representation. Identification of the condition, problem or diagnosis",
+        "element_property": true,
+        "term": {
+          "description": "Identification of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/condition-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-code"
+          }
+        },
+        "title": "Identification of the condition, problem or diagnosis",
+        "type": "string"
+      },
+      "code_coding": {
+        "binding_description": "Identification of the condition or diagnosis.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-code",
+        "binding_version": null,
+        "description": "[system#code representation.] Identification of the condition, problem or diagnosis",
+        "element_property": true,
+        "term": {
+          "description": "Identification of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/condition-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-code"
+          }
+        },
+        "title": "Identification of the condition, problem or diagnosis",
+        "type": "string"
+      },
+      "code_text": {
+        "binding_description": "Identification of the condition or diagnosis.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-code",
+        "binding_version": null,
+        "description": "[system#code representation.] Identification of the condition, problem or diagnosis",
+        "element_property": true,
+        "term": {
+          "description": "Identification of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/condition-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-code"
+          }
+        },
+        "title": "Identification of the condition, problem or diagnosis",
+        "type": "string"
+      },
+      "encounter": {
+        "backref": "condition",
+        "description": "[Text representation of Reference] The Encounter during which this Condition was created or to which the creation of this record is tightly associated.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Encounter"
+        ],
+        "title": "The Encounter during which this Condition was created",
+        "type": "string"
+      },
+      "evidence": {
+        "backref": "evidence_condition",
+        "binding_description": null,
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/clinical-findings",
+        "binding_version": null,
+        "description": "text representation. Supporting evidence / manifestations that are the basis of the Condition's verification status, such as evidence that confirmed or refuted the condition.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "term_url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+          }
+        },
+        "title": "Supporting evidence for the verification status",
+        "type": "array"
+      },
+      "evidence_coding": {
+        "backref": "evidence_condition",
+        "binding_description": null,
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/clinical-findings",
+        "binding_version": null,
+        "description": "[system#code representation.] Supporting evidence / manifestations that are the basis of the Condition's verification status, such as evidence that confirmed or refuted the condition.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "term_url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+          }
+        },
+        "title": "Supporting evidence for the verification status",
+        "type": "array"
+      },
+      "evidence_text": {
+        "backref": "evidence_condition",
+        "binding_description": null,
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/clinical-findings",
+        "binding_version": null,
+        "description": "[system#code representation.] Supporting evidence / manifestations that are the basis of the Condition's verification status, such as evidence that confirmed or refuted the condition.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "term_url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+          }
+        },
+        "title": "Supporting evidence for the verification status",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Business identifiers assigned to this condition by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Ids for this condition",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Business identifiers assigned to this condition by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Ids for this condition",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Business identifiers assigned to this condition by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Ids for this condition",
+        "type": "array"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] Additional information about the Condition. This is a general notes/comments entry  for description of the Condition, its diagnosis and prognosis.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional information about the Condition",
+        "type": "array"
+      },
+      "onsetAge": {
+        "description": "[Text representation of Age] Estimated or actual date or date-time  the condition began, in the opinion of the clinician.",
+        "element_property": true,
+        "one_of_many": "onset",
+        "one_of_many_required": false,
+        "title": "Estimated or actual date,  date-time, or age",
+        "type": "string"
+      },
+      "onsetDateTime": {
+        "description": "Estimated or actual date or date-time  the condition began, in the opinion of the clinician.",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "onset",
+        "one_of_many_required": false,
+        "title": "Estimated or actual date,  date-time, or age",
+        "type": "string"
+      },
+      "onsetPeriod": {
+        "description": "[Text representation of Period] Estimated or actual date or date-time  the condition began, in the opinion of the clinician.",
+        "element_property": true,
+        "one_of_many": "onset",
+        "one_of_many_required": false,
+        "title": "Estimated or actual date,  date-time, or age",
+        "type": "string"
+      },
+      "onsetRange": {
+        "description": "[Text representation of Range] Estimated or actual date or date-time  the condition began, in the opinion of the clinician.",
+        "element_property": true,
+        "one_of_many": "onset",
+        "one_of_many_required": false,
+        "title": "Estimated or actual date,  date-time, or age",
+        "type": "string"
+      },
+      "onsetString": {
+        "description": "Estimated or actual date or date-time  the condition began, in the opinion of the clinician.",
+        "element_property": true,
+        "one_of_many": "onset",
+        "one_of_many_required": false,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Estimated or actual date,  date-time, or age",
+        "type": "string"
+      },
+      "participant": {
+        "description": "[Text representation of ConditionParticipant] Indicates who or what participated in the activities related to the condition and how they were involved.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Who or what participated in the activities related to the condition and how they were involved",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "recordedDate": {
+        "description": "The recordedDate represents when this particular Condition record was created in the system, which is often a system-generated date.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "Date condition was first recorded",
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "Condition",
+        "default": "Condition",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "severity": {
+        "binding_description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-severity",
+        "binding_version": null,
+        "description": "text representation. A subjective assessment of the severity of the condition as evaluated by the clinician.",
+        "element_property": true,
+        "term": {
+          "description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-severity",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/condition-severity",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-severity"
+          }
+        },
+        "title": "Subjective severity of condition",
+        "type": "string"
+      },
+      "severity_coding": {
+        "binding_description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-severity",
+        "binding_version": null,
+        "description": "[system#code representation.] A subjective assessment of the severity of the condition as evaluated by the clinician.",
+        "element_property": true,
+        "term": {
+          "description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-severity",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/condition-severity",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-severity"
+          }
+        },
+        "title": "Subjective severity of condition",
+        "type": "string"
+      },
+      "severity_text": {
+        "binding_description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-severity",
+        "binding_version": null,
+        "description": "[system#code representation.] A subjective assessment of the severity of the condition as evaluated by the clinician.",
+        "element_property": true,
+        "term": {
+          "description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-severity",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/condition-severity",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-severity"
+          }
+        },
+        "title": "Subjective severity of condition",
+        "type": "string"
+      },
+      "stage": {
+        "description": "[Text representation of ConditionStage] A simple summary of the stage such as \"Stage 3\" or \"Early Onset\". The determination of the stage is disease-specific, such as cancer, retinopathy of prematurity, kidney diseases, Alzheimer's, or Parkinson disease.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Stage/grade, usually assessed formally",
+        "type": "array"
+      },
+      "subject": {
+        "backref": "condition",
+        "description": "[Text representation of Reference] Indicates the patient or group who the condition record is associated with.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Group"
+        ],
+        "title": "Who has the condition?",
+        "type": "string"
+      },
+      "verificationStatus": {
+        "binding_description": "The verification status to support or decline the clinical status of the condition or diagnosis.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+        "binding_version": "5.0.0",
+        "description": "text representation. The verification status to support the clinical status of the condition.  The verification status pertains to the condition, itself, not to any specific condition attribute.",
+        "element_property": true,
+        "term": {
+          "description": "The verification status to support or decline the clinical status of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-ver-status"
+          }
+        },
+        "title": "unconfirmed | provisional | differential | confirmed | refuted | entered-in-error",
+        "type": "string"
+      },
+      "verificationStatus_coding": {
+        "binding_description": "The verification status to support or decline the clinical status of the condition or diagnosis.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+        "binding_version": "5.0.0",
+        "description": "[system#code representation.] The verification status to support the clinical status of the condition.  The verification status pertains to the condition, itself, not to any specific condition attribute.",
+        "element_property": true,
+        "term": {
+          "description": "The verification status to support or decline the clinical status of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-ver-status"
+          }
+        },
+        "title": "unconfirmed | provisional | differential | confirmed | refuted | entered-in-error",
+        "type": "string"
+      },
+      "verificationStatus_text": {
+        "binding_description": "The verification status to support or decline the clinical status of the condition or diagnosis.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+        "binding_version": "5.0.0",
+        "description": "[system#code representation.] The verification status to support the clinical status of the condition.  The verification status pertains to the condition, itself, not to any specific condition attribute.",
+        "element_property": true,
+        "term": {
+          "description": "The verification status to support or decline the clinical status of the condition or diagnosis.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "required",
+            "term": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-ver-status"
+          }
+        },
+        "title": "unconfirmed | provisional | differential | confirmed | refuted | entered-in-error",
+        "type": "string"
+      }
+    },
+    "title": "Condition",
+    "type": "object"
+  },
+  "location.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Administrative",
+    "description": "Details and position information for a place. Details and position information for a place where services are provided and resources and participants may be stored, found, contained, or accommodated. [See https://hl7.org/fhir/R5/Location.html]",
+    "id": "location",
+    "links": [
+      {
+        "backref": "location",
+        "label": "Location_managingOrganization_Organization_location",
+        "multiplicity": "many_to_many",
+        "name": "managingOrganization",
+        "required": false,
+        "target_type": "organization"
+      },
+      {
+        "backref": "location",
+        "label": "Location_partOf_Location_location",
+        "multiplicity": "many_to_many",
+        "name": "partOf",
+        "required": false,
+        "target_type": "location"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "address": {
+        "description": "[Text representation of Address] Physical location",
+        "element_property": true,
+        "title": "Physical location",
+        "type": "string"
+      },
+      "alias": {
+        "description": "A list of alternate names that the location is known as, or was known as, in the past",
+        "element_property": true,
+        "items": {
+          "pattern": "[ \\r\\n\\t\\S]+",
+          "type": "string"
+        },
+        "title": "A list of alternate names that the location is known as, or was known as, in the past",
+        "type": "array"
+      },
+      "characteristic": {
+        "binding_description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibiliy).",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/location-characteristic",
+        "binding_version": null,
+        "description": "text representation. Collection of characteristics (attributes)",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibiliy).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/location-characteristic",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/location-characteristic",
+            "term_url": "http://hl7.org/fhir/ValueSet/location-characteristic"
+          }
+        },
+        "title": "Collection of characteristics (attributes)",
+        "type": "array"
+      },
+      "characteristic_coding": {
+        "binding_description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibiliy).",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/location-characteristic",
+        "binding_version": null,
+        "description": "[system#code representation.] Collection of characteristics (attributes)",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibiliy).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/location-characteristic",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/location-characteristic",
+            "term_url": "http://hl7.org/fhir/ValueSet/location-characteristic"
+          }
+        },
+        "title": "Collection of characteristics (attributes)",
+        "type": "array"
+      },
+      "characteristic_text": {
+        "binding_description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibiliy).",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/location-characteristic",
+        "binding_version": null,
+        "description": "[system#code representation.] Collection of characteristics (attributes)",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A custom attribute that could be provided at a service (e.g. Wheelchair accessibiliy).",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/location-characteristic",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/location-characteristic",
+            "term_url": "http://hl7.org/fhir/ValueSet/location-characteristic"
+          }
+        },
+        "title": "Collection of characteristics (attributes)",
+        "type": "array"
+      },
+      "contact": {
+        "description": "[Text representation of ExtendedContactDetail] The contact details of communication devices available at the location. This can include addresses, phone numbers, fax numbers, mobile numbers, email addresses and web sites.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Official contact details for the location",
+        "type": "array"
+      },
+      "description": {
+        "description": "Description of the Location, which helps in finding or referencing the place.",
+        "element_property": true,
+        "pattern": "\\s*(\\S|\\s)*",
+        "title": "Additional details about the location that could be displayed as further information to identify the location beyond its name",
+        "type": "string"
+      },
+      "endpoint": {
+        "backref": "endpoint_location",
+        "description": "[Text representation of Reference] Technical endpoints providing access to services operated for the location",
+        "element_property": true,
+        "enum_reference_types": [
+          "Endpoint"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Technical endpoints providing access to services operated for the location",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "form": {
+        "binding_description": "Physical form of the location.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/location-form",
+        "binding_version": null,
+        "description": "text representation. Physical form of the location, e.g. building, room, vehicle, road, virtual.",
+        "element_property": true,
+        "term": {
+          "description": "Physical form of the location.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/location-form",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/location-form",
+            "term_url": "http://hl7.org/fhir/ValueSet/location-form"
+          }
+        },
+        "title": "Physical form of the location",
+        "type": "string"
+      },
+      "form_coding": {
+        "binding_description": "Physical form of the location.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/location-form",
+        "binding_version": null,
+        "description": "[system#code representation.] Physical form of the location, e.g. building, room, vehicle, road, virtual.",
+        "element_property": true,
+        "term": {
+          "description": "Physical form of the location.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/location-form",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/location-form",
+            "term_url": "http://hl7.org/fhir/ValueSet/location-form"
+          }
+        },
+        "title": "Physical form of the location",
+        "type": "string"
+      },
+      "form_text": {
+        "binding_description": "Physical form of the location.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/location-form",
+        "binding_version": null,
+        "description": "[system#code representation.] Physical form of the location, e.g. building, room, vehicle, road, virtual.",
+        "element_property": true,
+        "term": {
+          "description": "Physical form of the location.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/location-form",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/location-form",
+            "term_url": "http://hl7.org/fhir/ValueSet/location-form"
+          }
+        },
+        "title": "Physical form of the location",
+        "type": "string"
+      },
+      "hoursOfOperation": {
+        "description": "[Text representation of Availability] What days/times during a week is this location usually open, and any exceptions where the location is not available.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "What days/times during a week is this location usually open (including exceptions)",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Unique code or number identifying the location to its users",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Unique code or number identifying the location to its users",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Unique code or number identifying the location to its users",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Unique code or number identifying the location to its users",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Unique code or number identifying the location to its users",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Unique code or number identifying the location to its users",
+        "type": "array"
+      },
+      "managingOrganization": {
+        "backref": "location",
+        "description": "[Text representation of Reference] The organization responsible for the provisioning and upkeep of the location.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "Organization responsible for provisioning and upkeep",
+        "type": "string"
+      },
+      "mode": {
+        "binding_description": "Indicates whether a resource instance represents a specific location or a class of locations.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/location-mode",
+        "binding_version": "5.0.0",
+        "description": "Indicates whether a resource instance represents a specific location or a class of locations.",
+        "element_property": true,
+        "enum_values": [
+          "instance",
+          "kind"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "instance | kind",
+        "type": "string"
+      },
+      "name": {
+        "description": "Name of the location as used by humans. Does not need to be unique.",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Name of the location as used by humans",
+        "type": "string"
+      },
+      "operationalStatus": {
+        "binding_description": "The operational status if the location (where typically a bed/room).",
+        "binding_strength": "preferred",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v2-0116",
+        "binding_version": null,
+        "description": "[Text representation of Coding] The operational status covers operation values most relevant to beds (but can also apply to rooms/units/chairs/etc. such as an isolation unit/dialysis chair). This typically covers concepts such as contamination, housekeeping, and other activities like maintenance.",
+        "element_property": true,
+        "title": "The operational status of the location (typically only for a bed/room)",
+        "type": "string"
+      },
+      "partOf": {
+        "backref": "location",
+        "description": "[Text representation of Reference] Another Location of which this Location is physically a part of.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Location"
+        ],
+        "title": "Another Location this one is physically a part of",
+        "type": "string"
+      },
+      "position": {
+        "description": "[Text representation of LocationPosition] The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same co-ordinate system used in KML).",
+        "element_property": true,
+        "title": "The absolute geographic location",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "Location",
+        "default": "Location",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "Indicates whether the location is still in use.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/location-status",
+        "binding_version": "5.0.0",
+        "description": "The status property covers the general availability of the resource, not the current value which may be covered by the operationStatus, or by a schedule/slots if they are configured for the location.",
+        "element_property": true,
+        "enum_values": [
+          "active",
+          "suspended",
+          "inactive"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "active | suspended | inactive",
+        "type": "string"
+      },
+      "type": {
+        "binding_description": "Indicates the type of function performed at the location.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType",
+        "binding_version": null,
+        "description": "text representation. Indicates the type of function performed at the location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Indicates the type of function performed at the location.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType"
+          }
+        },
+        "title": "Type of function performed",
+        "type": "array"
+      },
+      "type_coding": {
+        "binding_description": "Indicates the type of function performed at the location.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the type of function performed at the location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Indicates the type of function performed at the location.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType"
+          }
+        },
+        "title": "Type of function performed",
+        "type": "array"
+      },
+      "type_text": {
+        "binding_description": "Indicates the type of function performed at the location.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the type of function performed at the location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Indicates the type of function performed at the location.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType"
+          }
+        },
+        "title": "Type of function performed",
+        "type": "array"
+      },
+      "virtualService": {
+        "description": "[Text representation of VirtualServiceDetail] Connection details of a virtual service (e.g. shared conference call facility with dedicated number/details).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Connection details of a virtual service (e.g. conference call)",
+        "type": "array"
+      }
+    },
+    "title": "Location",
+    "type": "object"
+  },
+  "encounter.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "An interaction during which services are provided to the patient. An interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or assessing the health status of a patient.  Encounter is primarily used to record information about the actual activities that occurred, where Appointment is used to record planned activities. [See https://hl7.org/fhir/R5/Encounter.html]",
+    "id": "encounter",
+    "links": [
+      {
+        "backref": "encounter",
+        "label": "Encounter_subject_Patient_encounter",
+        "multiplicity": "many_to_many",
+        "name": "subject_Patient",
+        "required": false,
+        "target_type": "patient"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "account": {
+        "backref": "account_encounter",
+        "description": "[Text representation of Reference] The set of accounts that may be used for billing for this Encounter",
+        "element_property": true,
+        "enum_reference_types": [
+          "Account"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "The set of accounts that may be used for billing for this Encounter",
+        "type": "array"
+      },
+      "actualPeriod": {
+        "description": "[Text representation of Period] The actual start and end time of the encounter",
+        "element_property": true,
+        "title": "The actual start and end time of the encounter",
+        "type": "string"
+      },
+      "admission": {
+        "description": "[Text representation of EncounterAdmission] Details about the stay during which a healthcare service is provided.  This does not describe the event of admitting the patient, but rather any information that is relevant from the time of admittance until the time of discharge.",
+        "element_property": true,
+        "title": "Details about the admission to a healthcare service",
+        "type": "string"
+      },
+      "appointment": {
+        "backref": "appointment_encounter",
+        "description": "[Text representation of Reference] The appointment that scheduled this encounter",
+        "element_property": true,
+        "enum_reference_types": [
+          "Appointment"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "The appointment that scheduled this encounter",
+        "type": "array"
+      },
+      "basedOn": {
+        "backref": "basedOn_encounter",
+        "description": "[Text representation of Reference] The request this encounter satisfies (e.g. incoming referral or procedure request).",
+        "element_property": true,
+        "enum_reference_types": [
+          "CarePlan",
+          "DeviceRequest",
+          "MedicationRequest",
+          "ServiceRequest"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "The request that initiated this encounter",
+        "type": "array"
+      },
+      "careTeam": {
+        "backref": "careTeam_encounter",
+        "description": "[Text representation of Reference] The group(s) of individuals, organizations that are allocated to participate in this encounter. The participants backbone will record the actuals of when these individuals participated during the encounter.",
+        "element_property": true,
+        "enum_reference_types": [
+          "CareTeam"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "The group(s) that are allocated to participate in this encounter",
+        "type": "array"
+      },
+      "class_fhir": {
+        "binding_description": "Classification of the encounter.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/encounter-class",
+        "binding_version": null,
+        "description": "text representation. Concepts representing classification of patient encounter such as ambulatory (outpatient), inpatient, emergency, home health or others due to local variations.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Classification of the encounter.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/encounter-class",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://terminology.hl7.org/ValueSet/encounter-class",
+            "term_url": "http://terminology.hl7.org/ValueSet/encounter-class"
+          }
+        },
+        "title": "Classification of patient encounter context - e.g. Inpatient, outpatient",
+        "type": "array"
+      },
+      "class_fhir_coding": {
+        "binding_description": "Classification of the encounter.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/encounter-class",
+        "binding_version": null,
+        "description": "[system#code representation.] Concepts representing classification of patient encounter such as ambulatory (outpatient), inpatient, emergency, home health or others due to local variations.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Classification of the encounter.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/encounter-class",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://terminology.hl7.org/ValueSet/encounter-class",
+            "term_url": "http://terminology.hl7.org/ValueSet/encounter-class"
+          }
+        },
+        "title": "Classification of patient encounter context - e.g. Inpatient, outpatient",
+        "type": "array"
+      },
+      "class_fhir_text": {
+        "binding_description": "Classification of the encounter.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/encounter-class",
+        "binding_version": null,
+        "description": "[system#code representation.] Concepts representing classification of patient encounter such as ambulatory (outpatient), inpatient, emergency, home health or others due to local variations.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Classification of the encounter.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/encounter-class",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://terminology.hl7.org/ValueSet/encounter-class",
+            "term_url": "http://terminology.hl7.org/ValueSet/encounter-class"
+          }
+        },
+        "title": "Classification of patient encounter context - e.g. Inpatient, outpatient",
+        "type": "array"
+      },
+      "diagnosis": {
+        "description": "[Text representation of EncounterDiagnosis] The list of diagnosis relevant to this encounter",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "The list of diagnosis relevant to this encounter",
+        "type": "array"
+      },
+      "dietPreference": {
+        "binding_description": "Medical, cultural or ethical food preferences to help with catering requirements.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-diet",
+        "binding_version": null,
+        "description": "text representation. Diet preferences reported by the patient",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Medical, cultural or ethical food preferences to help with catering requirements.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-diet",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-diet",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-diet"
+          }
+        },
+        "title": "Diet preferences reported by the patient",
+        "type": "array"
+      },
+      "dietPreference_coding": {
+        "binding_description": "Medical, cultural or ethical food preferences to help with catering requirements.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-diet",
+        "binding_version": null,
+        "description": "[system#code representation.] Diet preferences reported by the patient",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Medical, cultural or ethical food preferences to help with catering requirements.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-diet",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-diet",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-diet"
+          }
+        },
+        "title": "Diet preferences reported by the patient",
+        "type": "array"
+      },
+      "dietPreference_text": {
+        "binding_description": "Medical, cultural or ethical food preferences to help with catering requirements.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-diet",
+        "binding_version": null,
+        "description": "[system#code representation.] Diet preferences reported by the patient",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Medical, cultural or ethical food preferences to help with catering requirements.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-diet",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-diet",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-diet"
+          }
+        },
+        "title": "Diet preferences reported by the patient",
+        "type": "array"
+      },
+      "episodeOfCare": {
+        "backref": "episodeOfCare_encounter",
+        "description": "[Text representation of Reference] Where a specific encounter should be classified as a part of a specific episode(s) of care this field should be used. This association can facilitate grouping of related encounters together for a specific purpose, such as government reporting, issue tracking, association via a common problem.  The association is recorded on the encounter as these are typically created after the episode of care and grouped on entry rather than editing the episode of care to append another encounter to it (the episode of care could span years).",
+        "element_property": true,
+        "enum_reference_types": [
+          "EpisodeOfCare"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Episode(s) of care that this encounter should be recorded against",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Identifier(s) by which this encounter is known",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Identifier(s) by which this encounter is known",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Identifier(s) by which this encounter is known",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Identifier(s) by which this encounter is known",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Identifier(s) by which this encounter is known",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Identifier(s) by which this encounter is known",
+        "type": "array"
+      },
+      "length": {
+        "description": "[Text representation of Duration] Actual quantity of time the encounter lasted. This excludes the time during leaves of absence.  When missing it is the time in between the start and end values.",
+        "element_property": true,
+        "title": "Actual quantity of time the encounter lasted (less time absent)",
+        "type": "string"
+      },
+      "location": {
+        "description": "[Text representation of EncounterLocation] List of locations where  the patient has been during this encounter.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "List of locations where the patient has been",
+        "type": "array"
+      },
+      "partOf": {
+        "backref": "encounter",
+        "description": "[Text representation of Reference] Another Encounter of which this encounter is a part of (administratively or in time).",
+        "element_property": true,
+        "enum_reference_types": [
+          "Encounter"
+        ],
+        "title": "Another Encounter this encounter is part of",
+        "type": "string"
+      },
+      "participant": {
+        "description": "[Text representation of EncounterParticipant] The list of people responsible for providing the service.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "List of participants involved in the encounter",
+        "type": "array"
+      },
+      "plannedEndDate": {
+        "description": "The planned end date/time (or discharge date) of the encounter",
+        "element_property": true,
+        "format": "date-time",
+        "title": "The planned end date/time (or discharge date) of the encounter",
+        "type": "string"
+      },
+      "plannedStartDate": {
+        "description": "The planned start date/time (or admission date) of the encounter",
+        "element_property": true,
+        "format": "date-time",
+        "title": "The planned start date/time (or admission date) of the encounter",
+        "type": "string"
+      },
+      "priority": {
+        "binding_description": "Indicates the urgency of the encounter.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-ActPriority",
+        "binding_version": null,
+        "description": "text representation. Indicates the urgency of the encounter",
+        "element_property": true,
+        "term": {
+          "description": "Indicates the urgency of the encounter.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-ActPriority",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v3-ActPriority",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-ActPriority"
+          }
+        },
+        "title": "Indicates the urgency of the encounter",
+        "type": "string"
+      },
+      "priority_coding": {
+        "binding_description": "Indicates the urgency of the encounter.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-ActPriority",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the urgency of the encounter",
+        "element_property": true,
+        "term": {
+          "description": "Indicates the urgency of the encounter.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-ActPriority",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v3-ActPriority",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-ActPriority"
+          }
+        },
+        "title": "Indicates the urgency of the encounter",
+        "type": "string"
+      },
+      "priority_text": {
+        "binding_description": "Indicates the urgency of the encounter.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-ActPriority",
+        "binding_version": null,
+        "description": "[system#code representation.] Indicates the urgency of the encounter",
+        "element_property": true,
+        "term": {
+          "description": "Indicates the urgency of the encounter.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-ActPriority",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v3-ActPriority",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-ActPriority"
+          }
+        },
+        "title": "Indicates the urgency of the encounter",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "reason": {
+        "description": "[Text representation of EncounterReason] The list of medical reasons that are expected to be addressed during the episode of care",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "The list of medical reasons that are expected to be addressed during the episode of care",
+        "type": "array"
+      },
+      "resourceType": {
+        "const": "Encounter",
+        "default": "Encounter",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "serviceProvider": {
+        "backref": "encounter",
+        "description": "[Text representation of Reference] The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed seperately) for an external consultation.  Refer to the colonoscopy example on the Encounter examples tab.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "The organization (facility) responsible for this encounter",
+        "type": "string"
+      },
+      "serviceType": {
+        "backref": "serviceType_encounter",
+        "binding_description": "Broad categorization of the service that is to be provided.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/service-type",
+        "binding_version": null,
+        "description": "text representation. Broad categorization of the service that is to be provided (e.g. cardiology).",
+        "element_property": true,
+        "enum_reference_types": [
+          "HealthcareService"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Broad categorization of the service that is to be provided.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/service-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/service-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/service-type"
+          }
+        },
+        "title": "Specific type of service",
+        "type": "array"
+      },
+      "serviceType_coding": {
+        "backref": "serviceType_encounter",
+        "binding_description": "Broad categorization of the service that is to be provided.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/service-type",
+        "binding_version": null,
+        "description": "[system#code representation.] Broad categorization of the service that is to be provided (e.g. cardiology).",
+        "element_property": true,
+        "enum_reference_types": [
+          "HealthcareService"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Broad categorization of the service that is to be provided.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/service-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/service-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/service-type"
+          }
+        },
+        "title": "Specific type of service",
+        "type": "array"
+      },
+      "serviceType_text": {
+        "backref": "serviceType_encounter",
+        "binding_description": "Broad categorization of the service that is to be provided.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/service-type",
+        "binding_version": null,
+        "description": "[system#code representation.] Broad categorization of the service that is to be provided (e.g. cardiology).",
+        "element_property": true,
+        "enum_reference_types": [
+          "HealthcareService"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Broad categorization of the service that is to be provided.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/service-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/service-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/service-type"
+          }
+        },
+        "title": "Specific type of service",
+        "type": "array"
+      },
+      "specialArrangement": {
+        "binding_description": "Special arrangements.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements",
+        "binding_version": null,
+        "description": "text representation. Any special requests that have been made for this encounter, such as the provision of specific equipment or other things.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Special arrangements.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements"
+          }
+        },
+        "title": "Wheelchair, translator, stretcher, etc",
+        "type": "array"
+      },
+      "specialArrangement_coding": {
+        "binding_description": "Special arrangements.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements",
+        "binding_version": null,
+        "description": "[system#code representation.] Any special requests that have been made for this encounter, such as the provision of specific equipment or other things.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Special arrangements.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements"
+          }
+        },
+        "title": "Wheelchair, translator, stretcher, etc",
+        "type": "array"
+      },
+      "specialArrangement_text": {
+        "binding_description": "Special arrangements.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements",
+        "binding_version": null,
+        "description": "[system#code representation.] Any special requests that have been made for this encounter, such as the provision of specific equipment or other things.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Special arrangements.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements"
+          }
+        },
+        "title": "Wheelchair, translator, stretcher, etc",
+        "type": "array"
+      },
+      "specialCourtesy": {
+        "binding_description": "Special courtesies.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy",
+        "binding_version": null,
+        "description": "text representation. Special courtesies that may be provided to the patient during the encounter (VIP, board member, professional courtesy).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Special courtesies.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy"
+          }
+        },
+        "title": "Special courtesies (VIP, board member)",
+        "type": "array"
+      },
+      "specialCourtesy_coding": {
+        "binding_description": "Special courtesies.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy",
+        "binding_version": null,
+        "description": "[system#code representation.] Special courtesies that may be provided to the patient during the encounter (VIP, board member, professional courtesy).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Special courtesies.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy"
+          }
+        },
+        "title": "Special courtesies (VIP, board member)",
+        "type": "array"
+      },
+      "specialCourtesy_text": {
+        "binding_description": "Special courtesies.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy",
+        "binding_version": null,
+        "description": "[system#code representation.] Special courtesies that may be provided to the patient during the encounter (VIP, board member, professional courtesy).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Special courtesies.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy"
+          }
+        },
+        "title": "Special courtesies (VIP, board member)",
+        "type": "array"
+      },
+      "status": {
+        "binding_description": "Current state of the encounter.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-status",
+        "binding_version": "5.0.0",
+        "description": "The current state of the encounter (not the state of the patient within the encounter - that is subjectState).",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "planned",
+          "in-progress",
+          "on-hold",
+          "discharged",
+          "completed",
+          "cancelled",
+          "discontinued",
+          "entered-in-error",
+          "unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "planned | in-progress | on-hold | discharged | completed | cancelled | discontinued | entered-in-error | unknown",
+        "type": "string"
+      },
+      "subject": {
+        "backref": "encounter",
+        "description": "[Text representation of Reference] The patient or group related to this encounter. In some use-cases the patient MAY not be present, such as a case meeting about a patient between several practitioners or a careteam.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Group"
+        ],
+        "title": "The patient or group related to this encounter",
+        "type": "string"
+      },
+      "subjectStatus": {
+        "binding_description": "Current status of the subject  within the encounter.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-subject-status",
+        "binding_version": null,
+        "description": "text representation. The subjectStatus value can be used to track the patient's status within the encounter. It details whether the patient has arrived or departed, has been triaged or is currently in a waiting status.",
+        "element_property": true,
+        "term": {
+          "description": "Current status of the subject  within the encounter.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-subject-status",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-subject-status",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-subject-status"
+          }
+        },
+        "title": "The current status of the subject in relation to the Encounter",
+        "type": "string"
+      },
+      "subjectStatus_coding": {
+        "binding_description": "Current status of the subject  within the encounter.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-subject-status",
+        "binding_version": null,
+        "description": "[system#code representation.] The subjectStatus value can be used to track the patient's status within the encounter. It details whether the patient has arrived or departed, has been triaged or is currently in a waiting status.",
+        "element_property": true,
+        "term": {
+          "description": "Current status of the subject  within the encounter.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-subject-status",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-subject-status",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-subject-status"
+          }
+        },
+        "title": "The current status of the subject in relation to the Encounter",
+        "type": "string"
+      },
+      "subjectStatus_text": {
+        "binding_description": "Current status of the subject  within the encounter.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-subject-status",
+        "binding_version": null,
+        "description": "[system#code representation.] The subjectStatus value can be used to track the patient's status within the encounter. It details whether the patient has arrived or departed, has been triaged or is currently in a waiting status.",
+        "element_property": true,
+        "term": {
+          "description": "Current status of the subject  within the encounter.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-subject-status",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-subject-status",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-subject-status"
+          }
+        },
+        "title": "The current status of the subject in relation to the Encounter",
+        "type": "string"
+      },
+      "type": {
+        "binding_description": "A specific code indicating type of service provided",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-type",
+        "binding_version": null,
+        "description": "text representation. Specific type of encounter (e.g. e-mail consultation, surgical day-care, skilled nursing, rehabilitation).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A specific code indicating type of service provided",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-type"
+          }
+        },
+        "title": "Specific type of encounter (e.g. e-mail consultation, surgical day-care, ...)",
+        "type": "array"
+      },
+      "type_coding": {
+        "binding_description": "A specific code indicating type of service provided",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-type",
+        "binding_version": null,
+        "description": "[system#code representation.] Specific type of encounter (e.g. e-mail consultation, surgical day-care, skilled nursing, rehabilitation).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A specific code indicating type of service provided",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-type"
+          }
+        },
+        "title": "Specific type of encounter (e.g. e-mail consultation, surgical day-care, ...)",
+        "type": "array"
+      },
+      "type_text": {
+        "binding_description": "A specific code indicating type of service provided",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/encounter-type",
+        "binding_version": null,
+        "description": "[system#code representation.] Specific type of encounter (e.g. e-mail consultation, surgical day-care, skilled nursing, rehabilitation).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A specific code indicating type of service provided",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/encounter-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/encounter-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/encounter-type"
+          }
+        },
+        "title": "Specific type of encounter (e.g. e-mail consultation, surgical day-care, ...)",
+        "type": "array"
+      },
+      "virtualService": {
+        "description": "[Text representation of VirtualServiceDetail] Connection details of a virtual service (e.g. conference call)",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Connection details of a virtual service (e.g. conference call)",
+        "type": "array"
+      }
+    },
+    "title": "Encounter",
+    "type": "object"
+  },
+  "research_subject.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Administrative",
+    "description": "Participant or object which is the recipient of investigative activities in a study. A ResearchSubject is a participant or object which is the recipient of investigative activities in a research study. [See https://hl7.org/fhir/R5/ResearchSubject.html]",
+    "id": "research_subject",
+    "links": [
+      {
+        "backref": "research_subject",
+        "label": "ResearchSubject_subject_Patient_research_subject",
+        "multiplicity": "many_to_many",
+        "name": "subject_Patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "research_subject",
+        "label": "ResearchSubject_subject_Specimen_research_subject",
+        "multiplicity": "many_to_many",
+        "name": "subject_Specimen",
+        "required": false,
+        "target_type": "specimen"
+      },
+      {
+        "backref": "research_subject",
+        "label": "ResearchSubject_subject_Medication_research_subject",
+        "multiplicity": "many_to_many",
+        "name": "subject_Medication",
+        "required": false,
+        "target_type": "medication"
+      },
+      {
+        "backref": "research_subject",
+        "label": "ResearchSubject_subject_Substance_research_subject",
+        "multiplicity": "many_to_many",
+        "name": "subject_Substance",
+        "required": false,
+        "target_type": "substance"
+      },
+      {
+        "backref": "research_subject",
+        "label": "ResearchSubject_study_ResearchStudy_research_subject",
+        "multiplicity": "many_to_many",
+        "name": "study",
+        "required": false,
+        "target_type": "research_study"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "actualComparisonGroup": {
+        "description": "The name of the arm in the study the subject actually followed as part of this study.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "What path was followed",
+        "type": "string"
+      },
+      "assignedComparisonGroup": {
+        "description": "The name of the arm in the study the subject is expected to follow as part of this study.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "What path should be followed",
+        "type": "string"
+      },
+      "consent": {
+        "backref": "consent_research_subject",
+        "description": "[Text representation of Reference] A record of the patient's informed agreement to participate in the study.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Consent"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Agreement to participate in study",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Identifiers assigned to this research subject for a study.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business Identifier for research subject in a study",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Identifiers assigned to this research subject for a study.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business Identifier for research subject in a study",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Identifiers assigned to this research subject for a study.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business Identifier for research subject in a study",
+        "type": "array"
+      },
+      "period": {
+        "description": "[Text representation of Period] The dates the subject began and ended their participation in the study.",
+        "element_property": true,
+        "title": "Start and end of participation",
+        "type": "string"
+      },
+      "progress": {
+        "description": "[Text representation of ResearchSubjectProgress] The current state (status) of the subject and resons for status change where appropriate.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Subject status",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "ResearchSubject",
+        "default": "ResearchSubject",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "Codes that convey the current publication status of the research study resource.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/publication-status",
+        "binding_version": "5.0.0",
+        "description": "The publication state of the resource (not of the subject).",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "draft",
+          "active",
+          "retired",
+          "unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "draft | active | retired | unknown",
+        "type": "string"
+      },
+      "study": {
+        "backref": "research_subject",
+        "description": "[Text representation of Reference] Reference to the study the subject is participating in.",
+        "element_property": true,
+        "enum_reference_types": [
+          "ResearchStudy"
+        ],
+        "title": "Study subject is part of",
+        "type": "string"
+      },
+      "subject": {
+        "backref": "research_subject",
+        "description": "[Text representation of Reference] The record of the person, animal or other entity involved in the study.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Group",
+          "Specimen",
+          "Device",
+          "Medication",
+          "Substance",
+          "BiologicallyDerivedProduct"
+        ],
+        "title": "Who or what is part of study",
+        "type": "string"
+      }
+    },
+    "title": "ResearchSubject",
+    "type": "object"
+  },
+  "diagnostic_report.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "A Diagnostic report - a combination of request information, atomic results, images, interpretation, as well as formatted reports. The findings and interpretation of diagnostic tests performed on patients, groups of patients, products, substances, devices, and locations, and/or specimens derived from these. The report includes clinical context such as requesting provider information, and some mix of atomic results, images, textual and coded interpretations, and formatted representation of diagnostic reports. The report also includes non-clinical context such as batch analysis and stability reporting of products and substances. [See https://hl7.org/fhir/R5/DiagnosticReport.html]",
+    "id": "diagnostic_report",
+    "links": [
+      {
+        "backref": "subject_diagnostic_report",
+        "label": "DiagnosticReport_subject_Patient_subject_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "subject_Patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "subject_diagnostic_report",
+        "label": "DiagnosticReport_subject_Location_subject_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "subject_Location",
+        "required": false,
+        "target_type": "location"
+      },
+      {
+        "backref": "subject_diagnostic_report",
+        "label": "DiagnosticReport_subject_Organization_subject_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "subject_Organization",
+        "required": false,
+        "target_type": "organization"
+      },
+      {
+        "backref": "subject_diagnostic_report",
+        "label": "DiagnosticReport_subject_Practitioner_subject_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "subject_Practitioner",
+        "required": false,
+        "target_type": "practitioner"
+      },
+      {
+        "backref": "subject_diagnostic_report",
+        "label": "DiagnosticReport_subject_Medication_subject_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "subject_Medication",
+        "required": false,
+        "target_type": "medication"
+      },
+      {
+        "backref": "subject_diagnostic_report",
+        "label": "DiagnosticReport_subject_Substance_subject_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "subject_Substance",
+        "required": false,
+        "target_type": "substance"
+      },
+      {
+        "backref": "diagnostic_report",
+        "label": "DiagnosticReport_encounter_Encounter_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "encounter",
+        "required": false,
+        "target_type": "encounter"
+      },
+      {
+        "backref": "performer_diagnostic_report",
+        "label": "DiagnosticReport_performer_PractitionerRole_performer_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "performer_PractitionerRole",
+        "required": false,
+        "target_type": "practitioner_role"
+      },
+      {
+        "backref": "result_diagnostic_report",
+        "label": "DiagnosticReport_result_Observation_result_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "result",
+        "required": false,
+        "target_type": "observation"
+      },
+      {
+        "backref": "specimen_diagnostic_report",
+        "label": "DiagnosticReport_specimen_Specimen_specimen_diagnostic_report",
+        "multiplicity": "many_to_many",
+        "name": "specimen",
+        "required": false,
+        "target_type": "specimen"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "basedOn": {
+        "backref": "basedOn_diagnostic_report",
+        "description": "[Text representation of Reference] Details concerning a service requested.",
+        "element_property": true,
+        "enum_reference_types": [
+          "CarePlan",
+          "ImmunizationRecommendation",
+          "MedicationRequest",
+          "NutritionOrder",
+          "ServiceRequest"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "What was requested",
+        "type": "array"
+      },
+      "category": {
+        "binding_description": "HL7 V2 table 0074",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections",
+        "binding_version": null,
+        "description": "text representation. A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "HL7 V2 table 0074",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections",
+            "term_url": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
+          }
+        },
+        "title": "Service category",
+        "type": "array"
+      },
+      "category_coding": {
+        "binding_description": "HL7 V2 table 0074",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections",
+        "binding_version": null,
+        "description": "[system#code representation.] A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "HL7 V2 table 0074",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections",
+            "term_url": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
+          }
+        },
+        "title": "Service category",
+        "type": "array"
+      },
+      "category_text": {
+        "binding_description": "HL7 V2 table 0074",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections",
+        "binding_version": null,
+        "description": "[system#code representation.] A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "HL7 V2 table 0074",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections",
+            "term_url": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
+          }
+        },
+        "title": "Service category",
+        "type": "array"
+      },
+      "code": {
+        "binding_description": "LOINC Codes for Diagnostic Reports",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/report-codes",
+        "binding_version": null,
+        "description": "text representation. A code or name that describes this diagnostic report.",
+        "element_property": true,
+        "term": {
+          "description": "LOINC Codes for Diagnostic Reports",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/report-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/report-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/report-codes"
+          }
+        },
+        "title": "Name/Code for this diagnostic report",
+        "type": "string"
+      },
+      "code_coding": {
+        "binding_description": "LOINC Codes for Diagnostic Reports",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/report-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] A code or name that describes this diagnostic report.",
+        "element_property": true,
+        "term": {
+          "description": "LOINC Codes for Diagnostic Reports",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/report-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/report-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/report-codes"
+          }
+        },
+        "title": "Name/Code for this diagnostic report",
+        "type": "string"
+      },
+      "code_text": {
+        "binding_description": "LOINC Codes for Diagnostic Reports",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/report-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] A code or name that describes this diagnostic report.",
+        "element_property": true,
+        "term": {
+          "description": "LOINC Codes for Diagnostic Reports",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/report-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/report-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/report-codes"
+          }
+        },
+        "title": "Name/Code for this diagnostic report",
+        "type": "string"
+      },
+      "composition": {
+        "backref": "diagnostic_report",
+        "description": "[Text representation of Reference] Reference to a Composition resource instance that provides structure for organizing the contents of the DiagnosticReport.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Composition"
+        ],
+        "title": "Reference to a Composition resource for the DiagnosticReport structure",
+        "type": "string"
+      },
+      "conclusion": {
+        "description": "Concise and clinically contextualized summary conclusion (interpretation/impression) of the diagnostic report.",
+        "element_property": true,
+        "pattern": "\\s*(\\S|\\s)*",
+        "title": "Clinical conclusion (interpretation) of test results",
+        "type": "string"
+      },
+      "conclusionCode": {
+        "binding_description": "SNOMED CT Clinical Findings",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/clinical-findings",
+        "binding_version": null,
+        "description": "text representation. One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Clinical Findings",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "term_url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+          }
+        },
+        "title": "Codes for the clinical conclusion of test results",
+        "type": "array"
+      },
+      "conclusionCode_coding": {
+        "binding_description": "SNOMED CT Clinical Findings",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/clinical-findings",
+        "binding_version": null,
+        "description": "[system#code representation.] One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Clinical Findings",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "term_url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+          }
+        },
+        "title": "Codes for the clinical conclusion of test results",
+        "type": "array"
+      },
+      "conclusionCode_text": {
+        "binding_description": "SNOMED CT Clinical Findings",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/clinical-findings",
+        "binding_version": null,
+        "description": "[system#code representation.] One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Clinical Findings",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "term_url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+          }
+        },
+        "title": "Codes for the clinical conclusion of test results",
+        "type": "array"
+      },
+      "effectiveDateTime": {
+        "description": "The time or time-period the observed values are related to. When the subject of the report is a patient, this is usually either the time of the procedure or of specimen collection(s), but very often the source of the date/time is not known, only the date/time itself.",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "effective",
+        "one_of_many_required": false,
+        "title": "Clinically relevant time/time-period for report",
+        "type": "string"
+      },
+      "effectivePeriod": {
+        "description": "[Text representation of Period] The time or time-period the observed values are related to. When the subject of the report is a patient, this is usually either the time of the procedure or of specimen collection(s), but very often the source of the date/time is not known, only the date/time itself.",
+        "element_property": true,
+        "one_of_many": "effective",
+        "one_of_many_required": false,
+        "title": "Clinically relevant time/time-period for report",
+        "type": "string"
+      },
+      "encounter": {
+        "backref": "diagnostic_report",
+        "description": "[Text representation of Reference] The healthcare event  (e.g. a patient and healthcare provider interaction) which this DiagnosticReport is about.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Encounter"
+        ],
+        "title": "Health care event when test ordered",
+        "type": "string"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Identifiers assigned to this report by the performer or other systems.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifier for report",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Identifiers assigned to this report by the performer or other systems.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifier for report",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Identifiers assigned to this report by the performer or other systems.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifier for report",
+        "type": "array"
+      },
+      "issued": {
+        "description": "The date and time that this version of the report was made available to providers, typically after the report was reviewed and verified.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "DateTime this version was made",
+        "type": "string"
+      },
+      "media": {
+        "description": "[Text representation of DiagnosticReportMedia] A list of key images or data associated with this report. The images or data are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Key images or data associated with this report",
+        "type": "array"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] Comments about the diagnostic report",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Comments about the diagnostic report",
+        "type": "array"
+      },
+      "performer": {
+        "backref": "performer_diagnostic_report",
+        "description": "[Text representation of Reference] The diagnostic service that is responsible for issuing the report.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Practitioner",
+          "PractitionerRole",
+          "Organization",
+          "CareTeam"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Responsible Diagnostic Service",
+        "type": "array"
+      },
+      "presentedForm": {
+        "description": "[Text representation of Attachment] Rich text representation of the entire result as issued by the diagnostic service. Multiple formats are allowed but they SHALL be semantically equivalent.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Entire report as issued",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "DiagnosticReport",
+        "default": "DiagnosticReport",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "result": {
+        "backref": "result_diagnostic_report",
+        "description": "[Text representation of Reference] [Observations](observation.html)  that are part of this diagnostic report.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Observation"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Observations",
+        "type": "array"
+      },
+      "resultsInterpreter": {
+        "backref": "resultsInterpreter_diagnostic_report",
+        "description": "[Text representation of Reference] The practitioner or organization that is responsible for the report's conclusions and interpretations.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Practitioner",
+          "PractitionerRole",
+          "Organization",
+          "CareTeam"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Primary result interpreter",
+        "type": "array"
+      },
+      "specimen": {
+        "backref": "specimen_diagnostic_report",
+        "description": "[Text representation of Reference] Details about the specimens on which this diagnostic report is based.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Specimen"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Specimens this report is based on",
+        "type": "array"
+      },
+      "status": {
+        "binding_description": "The status of the diagnostic report.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/diagnostic-report-status",
+        "binding_version": "5.0.0",
+        "description": "The status of the diagnostic report.",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "registered",
+          "partial",
+          "preliminary",
+          "modified",
+          "final",
+          "amended",
+          "corrected",
+          "appended",
+          "cancelled",
+          "entered-in-error",
+          "unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "registered | partial | preliminary | modified | final | amended | corrected | appended | cancelled | entered-in-error | unknown",
+        "type": "string"
+      },
+      "study": {
+        "backref": "study_diagnostic_report",
+        "description": "[Text representation of Reference] One or more links to full details of any study performed during the diagnostic investigation. An ImagingStudy might comprise a set of radiologic images obtained via a procedure that are analyzed as a group. Typically, this is imaging performed by DICOM enabled modalities, but this is not required. A fully enabled PACS viewer can use this information to provide views of the source images. A GenomicStudy might comprise one or more analyses, each serving a specific purpose. These analyses may vary in method (e.g., karyotyping, CNV, or SNV detection), performer, software, devices used, or regions targeted.",
+        "element_property": true,
+        "enum_reference_types": [
+          "GenomicStudy",
+          "ImagingStudy"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Reference to full details of an analysis associated with the diagnostic report",
+        "type": "array"
+      },
+      "subject": {
+        "backref": "subject_diagnostic_report",
+        "description": "[Text representation of Reference] The subject of the report. Usually, but not always, this is a patient. However, diagnostic services also perform analyses on specimens collected from a variety of other sources.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Group",
+          "Device",
+          "Location",
+          "Organization",
+          "Practitioner",
+          "Medication",
+          "Substance",
+          "BiologicallyDerivedProduct"
+        ],
+        "title": "The subject of the report - usually, but not always, the patient",
+        "type": "string"
+      },
+      "supportingInfo": {
+        "description": "[Text representation of DiagnosticReportSupportingInfo] This backbone element contains supporting information that was used in the creation of the report not included in the results already included in the report.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional information supporting the diagnostic report",
+        "type": "array"
+      }
+    },
+    "title": "DiagnosticReport",
+    "type": "object"
+  },
+  "procedure.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "An action that is being or was performed on an individual or entity. An action that is or was performed on or for a patient, practitioner, device, organization, or location. For example, this can be a physical intervention on a patient like an operation, or less invasive like long term services, counseling, or hypnotherapy.  This can be a quality or safety inspection for a location, organization, or device.  This can be an accreditation procedure on a practitioner for licensing. [See https://hl7.org/fhir/R5/Procedure.html]",
+    "id": "procedure",
+    "links": [
+      {
+        "backref": "subject_procedure",
+        "label": "Procedure_subject_Patient_subject_procedure",
+        "multiplicity": "many_to_many",
+        "name": "subject_Patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "subject_procedure",
+        "label": "Procedure_subject_Practitioner_subject_procedure",
+        "multiplicity": "many_to_many",
+        "name": "subject_Practitioner",
+        "required": false,
+        "target_type": "practitioner"
+      },
+      {
+        "backref": "subject_procedure",
+        "label": "Procedure_subject_Organization_subject_procedure",
+        "multiplicity": "many_to_many",
+        "name": "subject_Organization",
+        "required": false,
+        "target_type": "organization"
+      },
+      {
+        "backref": "subject_procedure",
+        "label": "Procedure_subject_Location_subject_procedure",
+        "multiplicity": "many_to_many",
+        "name": "subject_Location",
+        "required": false,
+        "target_type": "location"
+      },
+      {
+        "backref": "complication_procedure",
+        "label": "Procedure_complication_Condition_complication_procedure",
+        "multiplicity": "many_to_many",
+        "name": "complication",
+        "required": false,
+        "target_type": "condition"
+      },
+      {
+        "backref": "procedure",
+        "label": "Procedure_encounter_Encounter_procedure",
+        "multiplicity": "many_to_many",
+        "name": "encounter",
+        "required": false,
+        "target_type": "encounter"
+      },
+      {
+        "backref": "focus_procedure",
+        "label": "Procedure_focus_PractitionerRole_focus_procedure",
+        "multiplicity": "many_to_many",
+        "name": "focus_PractitionerRole",
+        "required": false,
+        "target_type": "practitioner_role"
+      },
+      {
+        "backref": "focus_procedure",
+        "label": "Procedure_focus_Specimen_focus_procedure",
+        "multiplicity": "many_to_many",
+        "name": "focus_Specimen",
+        "required": false,
+        "target_type": "specimen"
+      },
+      {
+        "backref": "partOf_procedure",
+        "label": "Procedure_partOf_Procedure_partOf_procedure",
+        "multiplicity": "many_to_many",
+        "name": "partOf_Procedure",
+        "required": false,
+        "target_type": "procedure"
+      },
+      {
+        "backref": "partOf_procedure",
+        "label": "Procedure_partOf_Observation_partOf_procedure",
+        "multiplicity": "many_to_many",
+        "name": "partOf_Observation",
+        "required": false,
+        "target_type": "observation"
+      },
+      {
+        "backref": "partOf_procedure",
+        "label": "Procedure_partOf_MedicationAdministration_partOf_procedure",
+        "multiplicity": "many_to_many",
+        "name": "partOf_MedicationAdministration",
+        "required": false,
+        "target_type": "medication_administration"
+      },
+      {
+        "backref": "reason_procedure",
+        "label": "Procedure_reason_DiagnosticReport_reason_procedure",
+        "multiplicity": "many_to_many",
+        "name": "reason_DiagnosticReport",
+        "required": false,
+        "target_type": "diagnostic_report"
+      },
+      {
+        "backref": "reason_procedure",
+        "label": "Procedure_reason_DocumentReference_reason_procedure",
+        "multiplicity": "many_to_many",
+        "name": "reason_DocumentReference",
+        "required": false,
+        "target_type": "document_reference"
+      },
+      {
+        "backref": "used_procedure",
+        "label": "Procedure_used_Medication_used_procedure",
+        "multiplicity": "many_to_many",
+        "name": "used_Medication",
+        "required": false,
+        "target_type": "medication"
+      },
+      {
+        "backref": "used_procedure",
+        "label": "Procedure_used_Substance_used_procedure",
+        "multiplicity": "many_to_many",
+        "name": "used_Substance",
+        "required": false,
+        "target_type": "substance"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "basedOn": {
+        "backref": "basedOn_procedure",
+        "description": "[Text representation of Reference] A reference to a resource that contains details of the request for this procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "CarePlan",
+          "ServiceRequest"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "A request for this procedure",
+        "type": "array"
+      },
+      "bodySite": {
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "text representation. Detailed and structured anatomical location information. Multiple locations are allowed - e.g. multiple punch biopsies of a lesion.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Target body sites",
+        "type": "array"
+      },
+      "bodySite_coding": {
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] Detailed and structured anatomical location information. Multiple locations are allowed - e.g. multiple punch biopsies of a lesion.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Target body sites",
+        "type": "array"
+      },
+      "bodySite_text": {
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] Detailed and structured anatomical location information. Multiple locations are allowed - e.g. multiple punch biopsies of a lesion.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Target body sites",
+        "type": "array"
+      },
+      "category": {
+        "binding_description": "A code that classifies a procedure for searching, sorting and display purposes.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-category",
+        "binding_version": null,
+        "description": "text representation. A code that classifies the procedure for searching, sorting and display purposes (e.g. \"Surgical Procedure\").",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A code that classifies a procedure for searching, sorting and display purposes.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-category"
+          }
+        },
+        "title": "Classification of the procedure",
+        "type": "array"
+      },
+      "category_coding": {
+        "binding_description": "A code that classifies a procedure for searching, sorting and display purposes.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A code that classifies the procedure for searching, sorting and display purposes (e.g. \"Surgical Procedure\").",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A code that classifies a procedure for searching, sorting and display purposes.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-category"
+          }
+        },
+        "title": "Classification of the procedure",
+        "type": "array"
+      },
+      "category_text": {
+        "binding_description": "A code that classifies a procedure for searching, sorting and display purposes.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-category",
+        "binding_version": null,
+        "description": "[system#code representation.] A code that classifies the procedure for searching, sorting and display purposes (e.g. \"Surgical Procedure\").",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A code that classifies a procedure for searching, sorting and display purposes.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-category",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-category",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-category"
+          }
+        },
+        "title": "Classification of the procedure",
+        "type": "array"
+      },
+      "code": {
+        "binding_description": "A code to identify a specific procedure .",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-code",
+        "binding_version": null,
+        "description": "text representation. The specific procedure that is performed. Use text if the exact nature of the procedure cannot be coded (e.g. \"Laparoscopic Appendectomy\").",
+        "element_property": true,
+        "term": {
+          "description": "A code to identify a specific procedure .",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-code"
+          }
+        },
+        "title": "Identification of the procedure",
+        "type": "string"
+      },
+      "code_coding": {
+        "binding_description": "A code to identify a specific procedure .",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-code",
+        "binding_version": null,
+        "description": "[system#code representation.] The specific procedure that is performed. Use text if the exact nature of the procedure cannot be coded (e.g. \"Laparoscopic Appendectomy\").",
+        "element_property": true,
+        "term": {
+          "description": "A code to identify a specific procedure .",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-code"
+          }
+        },
+        "title": "Identification of the procedure",
+        "type": "string"
+      },
+      "code_text": {
+        "binding_description": "A code to identify a specific procedure .",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-code",
+        "binding_version": null,
+        "description": "[system#code representation.] The specific procedure that is performed. Use text if the exact nature of the procedure cannot be coded (e.g. \"Laparoscopic Appendectomy\").",
+        "element_property": true,
+        "term": {
+          "description": "A code to identify a specific procedure .",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-code"
+          }
+        },
+        "title": "Identification of the procedure",
+        "type": "string"
+      },
+      "complication": {
+        "backref": "complication_procedure",
+        "binding_description": "Codes describing complications that resulted from a procedure.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-code",
+        "binding_version": null,
+        "description": "text representation. Any complications that occurred during the procedure, or in the immediate post-performance period. These are generally tracked separately from the notes, which will typically describe the procedure itself rather than any 'post procedure' issues.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing complications that resulted from a procedure.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/condition-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-code"
+          }
+        },
+        "title": "Complication following the procedure",
+        "type": "array"
+      },
+      "complication_coding": {
+        "backref": "complication_procedure",
+        "binding_description": "Codes describing complications that resulted from a procedure.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-code",
+        "binding_version": null,
+        "description": "[system#code representation.] Any complications that occurred during the procedure, or in the immediate post-performance period. These are generally tracked separately from the notes, which will typically describe the procedure itself rather than any 'post procedure' issues.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing complications that resulted from a procedure.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/condition-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-code"
+          }
+        },
+        "title": "Complication following the procedure",
+        "type": "array"
+      },
+      "complication_text": {
+        "backref": "complication_procedure",
+        "binding_description": "Codes describing complications that resulted from a procedure.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/condition-code",
+        "binding_version": null,
+        "description": "[system#code representation.] Any complications that occurred during the procedure, or in the immediate post-performance period. These are generally tracked separately from the notes, which will typically describe the procedure itself rather than any 'post procedure' issues.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing complications that resulted from a procedure.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/condition-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/condition-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/condition-code"
+          }
+        },
+        "title": "Complication following the procedure",
+        "type": "array"
+      },
+      "encounter": {
+        "backref": "procedure",
+        "description": "[Text representation of Reference] The Encounter during which this Procedure was created or performed or to which the creation of this record is tightly associated.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Encounter"
+        ],
+        "title": "The Encounter during which this Procedure was created",
+        "type": "string"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "focalDevice": {
+        "description": "[Text representation of ProcedureFocalDevice] A device that is implanted, removed or otherwise manipulated (calibration, battery replacement, fitting a prosthesis, attaching a wound-vac, etc.) as a focal portion of the Procedure.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Manipulated, implanted, or removed device",
+        "type": "array"
+      },
+      "focus": {
+        "backref": "focus_procedure",
+        "description": "[Text representation of Reference] Who is the target of the procedure when it is not the subject of record only.  If focus is not present, then subject is the focus.  If focus is present and the subject is one of the targets of the procedure, include subject as a focus as well. If focus is present and the subject is not included in focus, it implies that the procedure was only targeted on the focus. For example, when a caregiver is given education for a patient, the caregiver would be the focus and the procedure record is associated with the subject (e.g. patient).  For example, use focus when recording the target of the education, training, or counseling is the parent or relative of a patient.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Group",
+          "RelatedPerson",
+          "Practitioner",
+          "Organization",
+          "CareTeam",
+          "PractitionerRole",
+          "Specimen"
+        ],
+        "title": "Who is the target of the procedure when it is not the subject of record only",
+        "type": "string"
+      },
+      "followUp": {
+        "binding_description": "Specific follow up required for a procedure e.g. removal of sutures.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-followup",
+        "binding_version": null,
+        "description": "text representation. If the procedure required specific follow up - e.g. removal of sutures. The follow up may be represented as a simple note or could potentially be more complex, in which case the CarePlan resource can be used.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Specific follow up required for a procedure e.g. removal of sutures.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-followup",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-followup",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-followup"
+          }
+        },
+        "title": "Instructions for follow up",
+        "type": "array"
+      },
+      "followUp_coding": {
+        "binding_description": "Specific follow up required for a procedure e.g. removal of sutures.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-followup",
+        "binding_version": null,
+        "description": "[system#code representation.] If the procedure required specific follow up - e.g. removal of sutures. The follow up may be represented as a simple note or could potentially be more complex, in which case the CarePlan resource can be used.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Specific follow up required for a procedure e.g. removal of sutures.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-followup",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-followup",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-followup"
+          }
+        },
+        "title": "Instructions for follow up",
+        "type": "array"
+      },
+      "followUp_text": {
+        "binding_description": "Specific follow up required for a procedure e.g. removal of sutures.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-followup",
+        "binding_version": null,
+        "description": "[system#code representation.] If the procedure required specific follow up - e.g. removal of sutures. The follow up may be represented as a simple note or could potentially be more complex, in which case the CarePlan resource can be used.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Specific follow up required for a procedure e.g. removal of sutures.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-followup",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-followup",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-followup"
+          }
+        },
+        "title": "Instructions for follow up",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Business identifiers assigned to this procedure by the performer or other systems which remain constant as the resource is updated and is propagated from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Identifiers for this procedure",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Business identifiers assigned to this procedure by the performer or other systems which remain constant as the resource is updated and is propagated from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Identifiers for this procedure",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Business identifiers assigned to this procedure by the performer or other systems which remain constant as the resource is updated and is propagated from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Identifiers for this procedure",
+        "type": "array"
+      },
+      "instantiatesCanonical": {
+        "description": "The URL pointing to a FHIR-defined protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "PlanDefinition",
+          "ActivityDefinition",
+          "Measure",
+          "OperationDefinition",
+          "Questionnaire"
+        ],
+        "items": {
+          "pattern": "\\S*",
+          "type": "string"
+        },
+        "title": "Instantiates FHIR protocol or definition",
+        "type": "array"
+      },
+      "instantiatesUri": {
+        "description": "The URL pointing to an externally maintained protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
+        "element_property": true,
+        "items": {
+          "pattern": "\\S*",
+          "type": "string"
+        },
+        "title": "Instantiates external protocol or definition",
+        "type": "array"
+      },
+      "location": {
+        "backref": "location_procedure",
+        "description": "[Text representation of Reference] The location where the procedure actually happened.  E.g. a newborn at home, a tracheostomy at a restaurant.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Location"
+        ],
+        "title": "Where the procedure happened",
+        "type": "string"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] Any other notes and comments about the procedure.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional information about the procedure",
+        "type": "array"
+      },
+      "occurrenceAge": {
+        "description": "[Text representation of Age] Estimated or actual date, date-time, period, or age when the procedure did occur or is occurring.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
+        "element_property": true,
+        "one_of_many": "occurrence",
+        "one_of_many_required": false,
+        "title": "When the procedure occurred or is occurring",
+        "type": "string"
+      },
+      "occurrenceDateTime": {
+        "description": "Estimated or actual date, date-time, period, or age when the procedure did occur or is occurring.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "occurrence",
+        "one_of_many_required": false,
+        "title": "When the procedure occurred or is occurring",
+        "type": "string"
+      },
+      "occurrencePeriod": {
+        "description": "[Text representation of Period] Estimated or actual date, date-time, period, or age when the procedure did occur or is occurring.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
+        "element_property": true,
+        "one_of_many": "occurrence",
+        "one_of_many_required": false,
+        "title": "When the procedure occurred or is occurring",
+        "type": "string"
+      },
+      "occurrenceRange": {
+        "description": "[Text representation of Range] Estimated or actual date, date-time, period, or age when the procedure did occur or is occurring.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
+        "element_property": true,
+        "one_of_many": "occurrence",
+        "one_of_many_required": false,
+        "title": "When the procedure occurred or is occurring",
+        "type": "string"
+      },
+      "occurrenceString": {
+        "description": "Estimated or actual date, date-time, period, or age when the procedure did occur or is occurring.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
+        "element_property": true,
+        "one_of_many": "occurrence",
+        "one_of_many_required": false,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "When the procedure occurred or is occurring",
+        "type": "string"
+      },
+      "occurrenceTiming": {
+        "description": "[Text representation of Timing] Estimated or actual date, date-time, period, or age when the procedure did occur or is occurring.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
+        "element_property": true,
+        "one_of_many": "occurrence",
+        "one_of_many_required": false,
+        "title": "When the procedure occurred or is occurring",
+        "type": "string"
+      },
+      "outcome": {
+        "binding_description": "An outcome of a procedure - whether it was resolved or otherwise.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-outcome",
+        "binding_version": null,
+        "description": "text representation. The outcome of the procedure - did it resolve the reasons for the procedure being performed?",
+        "element_property": true,
+        "term": {
+          "description": "An outcome of a procedure - whether it was resolved or otherwise.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-outcome",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-outcome",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-outcome"
+          }
+        },
+        "title": "The result of procedure",
+        "type": "string"
+      },
+      "outcome_coding": {
+        "binding_description": "An outcome of a procedure - whether it was resolved or otherwise.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-outcome",
+        "binding_version": null,
+        "description": "[system#code representation.] The outcome of the procedure - did it resolve the reasons for the procedure being performed?",
+        "element_property": true,
+        "term": {
+          "description": "An outcome of a procedure - whether it was resolved or otherwise.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-outcome",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-outcome",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-outcome"
+          }
+        },
+        "title": "The result of procedure",
+        "type": "string"
+      },
+      "outcome_text": {
+        "binding_description": "An outcome of a procedure - whether it was resolved or otherwise.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-outcome",
+        "binding_version": null,
+        "description": "[system#code representation.] The outcome of the procedure - did it resolve the reasons for the procedure being performed?",
+        "element_property": true,
+        "term": {
+          "description": "An outcome of a procedure - whether it was resolved or otherwise.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-outcome",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-outcome",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-outcome"
+          }
+        },
+        "title": "The result of procedure",
+        "type": "string"
+      },
+      "partOf": {
+        "backref": "partOf_procedure",
+        "description": "[Text representation of Reference] A larger event of which this particular procedure is a component or step.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Procedure",
+          "Observation",
+          "MedicationAdministration"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Part of referenced event",
+        "type": "array"
+      },
+      "performer": {
+        "description": "[Text representation of ProcedurePerformer] Indicates who or what performed the procedure and how they were involved.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Who performed the procedure and what they did",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "reason": {
+        "backref": "reason_procedure",
+        "binding_description": "A code that identifies the reason a procedure is  required.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-reason",
+        "binding_version": null,
+        "description": "text representation. The coded reason or reference why the procedure was performed. This may be a coded entity of some type, be present as text, or be a reference to one of several resources that justify the procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "Procedure",
+          "DiagnosticReport",
+          "DocumentReference"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A code that identifies the reason a procedure is  required.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-reason"
+          }
+        },
+        "title": "The justification that the procedure was performed",
+        "type": "array"
+      },
+      "reason_coding": {
+        "backref": "reason_procedure",
+        "binding_description": "A code that identifies the reason a procedure is  required.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] The coded reason or reference why the procedure was performed. This may be a coded entity of some type, be present as text, or be a reference to one of several resources that justify the procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "Procedure",
+          "DiagnosticReport",
+          "DocumentReference"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A code that identifies the reason a procedure is  required.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-reason"
+          }
+        },
+        "title": "The justification that the procedure was performed",
+        "type": "array"
+      },
+      "reason_text": {
+        "backref": "reason_procedure",
+        "binding_description": "A code that identifies the reason a procedure is  required.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] The coded reason or reference why the procedure was performed. This may be a coded entity of some type, be present as text, or be a reference to one of several resources that justify the procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "Procedure",
+          "DiagnosticReport",
+          "DocumentReference"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A code that identifies the reason a procedure is  required.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-reason"
+          }
+        },
+        "title": "The justification that the procedure was performed",
+        "type": "array"
+      },
+      "recorded": {
+        "description": "The date the occurrence of the procedure was first captured in the record regardless of Procedure.status (potentially after the occurrence of the event).",
+        "element_property": true,
+        "format": "date-time",
+        "title": "When the procedure was first captured in the subject's record",
+        "type": "string"
+      },
+      "recorder": {
+        "backref": "recorder_procedure",
+        "description": "[Text representation of Reference] Individual who recorded the record and takes responsibility for its content.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "RelatedPerson",
+          "Practitioner",
+          "PractitionerRole"
+        ],
+        "title": "Who recorded the procedure",
+        "type": "string"
+      },
+      "report": {
+        "backref": "report_procedure",
+        "description": "[Text representation of Reference] This could be a histology result, pathology report, surgical report, etc.",
+        "element_property": true,
+        "enum_reference_types": [
+          "DiagnosticReport",
+          "DocumentReference",
+          "Composition"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Any report resulting from the procedure",
+        "type": "array"
+      },
+      "reportedBoolean": {
+        "description": "Indicates if this record was captured as a secondary 'reported' record rather than as an original primary source-of-truth record.  It may also indicate the source of the report.",
+        "element_property": true,
+        "one_of_many": "reported",
+        "one_of_many_required": false,
+        "title": "Reported rather than primary record",
+        "type": "boolean"
+      },
+      "reportedReference": {
+        "backref": "reportedReference_procedure",
+        "description": "[Text representation of Reference] Indicates if this record was captured as a secondary 'reported' record rather than as an original primary source-of-truth record.  It may also indicate the source of the report.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "RelatedPerson",
+          "Practitioner",
+          "PractitionerRole",
+          "Organization"
+        ],
+        "one_of_many": "reported",
+        "one_of_many_required": false,
+        "title": "Reported rather than primary record",
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "Procedure",
+        "default": "Procedure",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "A code specifying the state of the procedure.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/event-status",
+        "binding_version": "5.0.0",
+        "description": "A code specifying the state of the procedure. Generally, this will be the in-progress or completed state.",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "preparation",
+          "in-progress",
+          "not-done",
+          "on-hold",
+          "stopped",
+          "completed",
+          "entered-in-error",
+          "unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown",
+        "type": "string"
+      },
+      "statusReason": {
+        "binding_description": "A code that identifies the reason a procedure was not performed.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason",
+        "binding_version": null,
+        "description": "text representation. Captures the reason for the current state of the procedure.",
+        "element_property": true,
+        "term": {
+          "description": "A code that identifies the reason a procedure was not performed.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason"
+          }
+        },
+        "title": "Reason for current status",
+        "type": "string"
+      },
+      "statusReason_coding": {
+        "binding_description": "A code that identifies the reason a procedure was not performed.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Captures the reason for the current state of the procedure.",
+        "element_property": true,
+        "term": {
+          "description": "A code that identifies the reason a procedure was not performed.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason"
+          }
+        },
+        "title": "Reason for current status",
+        "type": "string"
+      },
+      "statusReason_text": {
+        "binding_description": "A code that identifies the reason a procedure was not performed.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Captures the reason for the current state of the procedure.",
+        "element_property": true,
+        "term": {
+          "description": "A code that identifies the reason a procedure was not performed.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason"
+          }
+        },
+        "title": "Reason for current status",
+        "type": "string"
+      },
+      "subject": {
+        "backref": "subject_procedure",
+        "description": "[Text representation of Reference] On whom or on what the procedure was performed. This is usually an individual human, but can also be performed on animals, groups of humans or animals, organizations or practitioners (for licensing), locations or devices (for safety inspections or regulatory authorizations).  If the actual focus of the procedure is different from the subject, the focus element specifies the actual focus of the procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Group",
+          "Device",
+          "Practitioner",
+          "Organization",
+          "Location"
+        ],
+        "title": "Individual or entity the procedure was performed on",
+        "type": "string"
+      },
+      "supportingInfo": {
+        "backref": "supportingInfo_procedure",
+        "description": "[Text representation of Reference] Other resources from the patient record that may be relevant to the procedure.  The information from these resources was either used to create the instance or is provided to help with its interpretation. This extension should not be used if more specific inline elements or extensions are available.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Extra information relevant to the procedure",
+        "type": "array"
+      },
+      "used": {
+        "backref": "used_procedure",
+        "binding_description": "Codes describing items used during a procedure.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/device-type",
+        "binding_version": null,
+        "description": "text representation. Identifies medications, devices and any other substance used as part of the procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Device",
+          "Medication",
+          "Substance",
+          "BiologicallyDerivedProduct"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing items used during a procedure.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/device-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/device-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/device-type"
+          }
+        },
+        "title": "Items used during procedure",
+        "type": "array"
+      },
+      "used_coding": {
+        "backref": "used_procedure",
+        "binding_description": "Codes describing items used during a procedure.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/device-type",
+        "binding_version": null,
+        "description": "[system#code representation.] Identifies medications, devices and any other substance used as part of the procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Device",
+          "Medication",
+          "Substance",
+          "BiologicallyDerivedProduct"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing items used during a procedure.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/device-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/device-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/device-type"
+          }
+        },
+        "title": "Items used during procedure",
+        "type": "array"
+      },
+      "used_text": {
+        "backref": "used_procedure",
+        "binding_description": "Codes describing items used during a procedure.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/device-type",
+        "binding_version": null,
+        "description": "[system#code representation.] Identifies medications, devices and any other substance used as part of the procedure.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Device",
+          "Medication",
+          "Substance",
+          "BiologicallyDerivedProduct"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing items used during a procedure.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/device-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/device-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/device-type"
+          }
+        },
+        "title": "Items used during procedure",
+        "type": "array"
+      }
+    },
+    "title": "Procedure",
+    "type": "object"
+  },
+  "organization.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Administrative",
+    "description": "A grouping of people or organizations with a common purpose. A formally or informally recognized grouping of people or organizations formed for the purpose of achieving some form of collective action. Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, payer/insurer, etc. [See https://hl7.org/fhir/R5/Organization.html]",
+    "id": "organization",
+    "links": [
+      {
+        "backref": "organization",
+        "label": "Organization_partOf_Organization_organization",
+        "multiplicity": "many_to_many",
+        "name": "partOf",
+        "required": false,
+        "target_type": "organization"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "active": {
+        "description": "Whether the organization's record is still in active use",
+        "element_property": true,
+        "title": "Whether the organization's record is still in active use",
+        "type": "boolean"
+      },
+      "alias": {
+        "description": "A list of alternate names that the organization is known as, or was known as in the past",
+        "element_property": true,
+        "items": {
+          "pattern": "[ \\r\\n\\t\\S]+",
+          "type": "string"
+        },
+        "title": "A list of alternate names that the organization is known as, or was known as in the past",
+        "type": "array"
+      },
+      "contact": {
+        "description": "[Text representation of ExtendedContactDetail] The contact details of communication devices available relevant to the specific Organization. This can include addresses, phone numbers, fax numbers, mobile numbers, email addresses and web sites.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Official contact details for the Organization",
+        "type": "array"
+      },
+      "description": {
+        "description": "Description of the organization, which helps provide additional general context on the organization to ensure that the correct organization is selected.",
+        "element_property": true,
+        "pattern": "\\s*(\\S|\\s)*",
+        "title": "Additional details about the Organization that could be displayed as further information to identify the Organization beyond its name",
+        "type": "string"
+      },
+      "endpoint": {
+        "backref": "endpoint_organization",
+        "description": "[Text representation of Reference] Technical endpoints providing access to services operated for the organization",
+        "element_property": true,
+        "enum_reference_types": [
+          "Endpoint"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Technical endpoints providing access to services operated for the organization",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Identifies this organization  across multiple systems",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Identifier for the organization that is used to identify the organization across multiple disparate systems.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Identifies this organization  across multiple systems",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Identifier for the organization that is used to identify the organization across multiple disparate systems.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Identifies this organization  across multiple systems",
+        "type": "array"
+      },
+      "name": {
+        "description": "A name associated with the organization.",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Name used for the organization",
+        "type": "string"
+      },
+      "partOf": {
+        "backref": "organization",
+        "description": "[Text representation of Reference] The organization of which this organization forms a part",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "The organization of which this organization forms a part",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "qualification": {
+        "description": "[Text representation of OrganizationQualification] The official certifications, accreditations, training, designations and licenses that authorize and/or otherwise endorse the provision of care by the organization.  For example, an approval to provide a type of services issued by a certifying body (such as the US Joint Commission) to an organization.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Qualifications, certifications, accreditations, licenses, training, etc. pertaining to the provision of care",
+        "type": "array"
+      },
+      "resourceType": {
+        "const": "Organization",
+        "default": "Organization",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "type": {
+        "binding_description": "Used to categorize the organization.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/organization-type",
+        "binding_version": null,
+        "description": "text representation. The kind(s) of organization that this is.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Used to categorize the organization.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/organization-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/organization-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/organization-type"
+          }
+        },
+        "title": "Kind of organization",
+        "type": "array"
+      },
+      "type_coding": {
+        "binding_description": "Used to categorize the organization.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/organization-type",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind(s) of organization that this is.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Used to categorize the organization.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/organization-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/organization-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/organization-type"
+          }
+        },
+        "title": "Kind of organization",
+        "type": "array"
+      },
+      "type_text": {
+        "binding_description": "Used to categorize the organization.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/organization-type",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind(s) of organization that this is.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Used to categorize the organization.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/organization-type",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/organization-type",
+            "term_url": "http://hl7.org/fhir/ValueSet/organization-type"
+          }
+        },
+        "title": "Kind of organization",
+        "type": "array"
+      }
+    },
+    "title": "Organization",
+    "type": "object"
+  },
+  "_terms.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "RIN": {
+      "description": "A numerical assessment of the integrity of RNA based on the entire electrophoretic trace of the RNA sample including the presence or absence of degradation products.\n",
+      "termDef": {
+        "cde_id": 5278775,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Biospecimen RNA Integrity Number Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5278775&version=1.0"
+      }
+    },
+    "UUID": {
+      "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+      "termDef": {
+        "cde_id": "C54100",
+        "cde_version": null,
+        "source": "NCIt",
+        "term": "Universally Unique Identifier",
+        "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+      }
+    },
+    "data_category": {
+      "description": "Broad categorization of the contents of the data file.\n"
+    },
+    "data_file_error_type": {
+      "description": "Type of error for the data file object.\n"
+    },
+    "data_format": {
+      "description": "Format of the data files.\n"
+    },
+    "data_type": {
+      "description": "Specific content type of the data file. (CMG)\n"
+    },
+    "datetime": {
+      "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+    },
+    "encoding": {
+      "description": "Version of ASCII encoding of quality values found in the file.\n",
+      "termDef": {
+        "cde_id": null,
+        "cde_version": null,
+        "source": "FastQC",
+        "term": "Encoding",
+        "term_url": "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/1%20Basic%20Statistics.html"
+      }
+    },
+    "file_format": {
+      "description": "The format of the data file object.\n"
+    },
+    "file_name": {
+      "description": "The name (or part of a name) of a file (of any type).\n"
+    },
+    "file_size": {
+      "description": "The size of the data file (object) in bytes.\n"
+    },
+    "file_state": {
+      "description": "The current state of the data file object.\n"
+    },
+    "ga4gh_drs_uri": {
+      "description": "DRS URI as defined by GA4GH DRS spec for pointers to file objects.\n"
+    },
+    "id": "_terms",
+    "md5sum": {
+      "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
+    },
+    "microsatellite_instability_abnormal": {
+      "description": "The yes/no indicator to signify the status of a tumor for microsatellite instability.\n",
+      "termDef": {
+        "cde_id": 3123142,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Microsatellite Instability Occurrence Indicator",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3123142&version=1.0"
+      }
+    },
+    "morphology": {
+      "description": "The third edition of the International Classification of Diseases for Oncology, published in 2000 used principally in tumor and cancer registries for coding the site (topography) and the histology (morphology) of neoplasms. The study of the structure of the cells and their arrangement to constitute tissues and, finally, the association among these to form organs. In pathology, the microscopic process of identifying normal and abnormal morphologic characteristics in tissues, by employing various cytochemical and immunocytochemical stains. A system of numbered categories for representation of data.\n",
+      "termDef": {
+        "cde_id": 3226275,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "International Classification of Diseases for Oncology, Third Edition ICD-O-3 Histology Code",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3226275&version=1.0"
+      }
+    },
+    "new_event_anatomic_site": {
+      "description": "Text term to specify the anatomic location of the return of tumor after treatment.\n",
+      "termDef": {
+        "cde_id": 3108271,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "New Neoplasm Event Occurrence Anatomic Site",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3108271&version=2.0"
+      }
+    },
+    "new_event_type": {
+      "description": "Text term to identify a new tumor event.\n",
+      "termDef": {
+        "cde_id": 3119721,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "New Neoplasm Event Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3119721&version=1.0"
+      }
+    },
+    "normal_tumor_genotype_snp_match": {
+      "description": "Text term that represents whether or not the genotype of the normal tumor matches or if the data is not available.\n",
+      "termDef": {
+        "cde_id": 4588156,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Normal Tumor Genotype Match Indicator",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4588156&version=1.0"
+      }
+    },
+    "number_proliferating_cells": {
+      "description": "Numeric value that represents the count of proliferating cells determined during pathologic review of the sample slide(s).\n",
+      "termDef": {
+        "cde_id": 5432636,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Pathology Review Slide Proliferating Cell Count",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432636&version=1.0"
+      }
+    },
+    "oct_embedded": {
+      "description": "Indicator of whether or not the sample was embedded in Optimal Cutting Temperature (OCT) compound.\n",
+      "termDef": {
+        "cde_id": 5432538,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Tissue Sample Optimal Cutting Temperature Compound Embedding Indicator",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432538&version=1.0"
+      }
+    },
+    "percent_eosinophil_infiltration": {
+      "description": "Numeric value to represent the percentage of infiltration by eosinophils in a tumor sample or specimen.\n",
+      "termDef": {
+        "cde_id": 2897700,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "Specimen Eosinophilia Percentage Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897700&version=2.0"
+      }
+    },
+    "percent_gc_content": {
+      "description": "The overall %GC of all bases in all sequences.\n",
+      "termDef": {
+        "cde_id": null,
+        "cde_version": null,
+        "source": "FastQC",
+        "term": "%GC",
+        "term_url": "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/1%20Basic%20Statistics.html"
+      }
+    },
+    "percent_granulocyte_infiltration": {
+      "description": "Numeric value to represent the percentage of infiltration by granulocytes in a tumor sample or specimen.\n",
+      "termDef": {
+        "cde_id": 2897705,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "Specimen Granulocyte Infiltration Percentage Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897705&version=2.0"
+      }
+    },
+    "percent_inflam_infiltration": {
+      "description": "Numeric value to represent local response to cellular injury, marked by capillary dilatation, edema and leukocyte infiltration; clinically, inflammation is manifest by reddness, heat, pain, swelling and loss of function, with the need to heal damaged tissue.\n",
+      "termDef": {
+        "cde_id": 2897695,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Specimen Inflammation Change Percentage Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897695&version=1.0"
+      }
+    },
+    "percent_lymphocyte_infiltration": {
+      "description": "Numeric value to represent the percentage of infiltration by lymphocytes in a solid tissue normal sample or specimen.\n",
+      "termDef": {
+        "cde_id": 2897710,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "Specimen Lymphocyte Infiltration Percentage Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897710&version=2.0"
+      }
+    },
+    "percent_monocyte_infiltration": {
+      "description": "Numeric value to represent the percentage of monocyte infiltration in a sample or specimen.\n",
+      "termDef": {
+        "cde_id": 5455535,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Specimen Monocyte Infiltration Percentage Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5455535&version=1.0"
+      }
+    },
+    "percent_necrosis": {
+      "description": "Numeric value to represent the percentage of cell death in a malignant tumor sample or specimen.\n",
+      "termDef": {
+        "cde_id": 2841237,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Malignant Neoplasm Necrosis Percentage Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841237&version=1.0"
+      }
+    },
+    "percent_neutrophil_infiltration": {
+      "description": "Numeric value to represent the percentage of infiltration by neutrophils in a tumor sample or specimen.\n",
+      "termDef": {
+        "cde_id": 2841267,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Malignant Neoplasm Neutrophil Infiltration Percentage Cell Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841267&version=1.0"
+      }
+    },
+    "percent_normal_cells": {
+      "description": "Numeric value to represent the percentage of normal cell content in a malignant tumor sample or specimen.\n",
+      "termDef": {
+        "cde_id": 2841233,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Malignant Neoplasm Normal Cell Percentage Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841233&version=1.0"
+      }
+    },
+    "percent_stromal_cells": {
+      "description": "Numeric value to represent the percentage of reactive cells that are present in a malignant tumor sample or specimen but are not malignant such as fibroblasts, vascular structures, etc.\n",
+      "termDef": {
+        "cde_id": 2841241,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Malignant Neoplasm Stromal Cell Percentage Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841241&version=1.0"
+      }
+    },
+    "percent_tumor_cells": {
+      "description": "Numeric value that represents the percentage of infiltration by granulocytes in a sample.\n",
+      "termDef": {
+        "cde_id": 5432686,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Specimen Tumor Cell Percentage Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432686&version=1.0"
+      }
+    },
+    "percent_tumor_nuclei": {
+      "description": "Numeric value to represent the percentage of tumor nuclei in a malignant neoplasm sample or specimen.\n",
+      "termDef": {
+        "cde_id": 2841225,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Malignant Neoplasm Neoplasm Nucleus Percentage Cell Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841225&version=1.0"
+      }
+    },
+    "perineural_invasion_present": {
+      "description": "a yes/no indicator to ask if perineural invasion or infiltration of tumor or cancer is present.\n",
+      "termDef": {
+        "cde_id": 64181,
+        "cde_version": 3.0,
+        "source": "caDSR",
+        "term": "Tumor Perineural Invasion Ind",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=64181&version=3.0"
+      }
+    },
+    "platform": {
+      "description": "Name of the platform used to obtain data.\n"
+    },
+    "portion_number": {
+      "description": "Numeric value that represents the sequential number assigned to a portion of the sample.\n",
+      "termDef": {
+        "cde_id": 5432711,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Biospecimen Portion Sequence Number",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432711&version=1.0"
+      }
+    },
+    "portion_weight": {
+      "description": "Numeric value that represents the sample portion weight, measured in milligrams.\n",
+      "termDef": {
+        "cde_id": 5432593,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Biospecimen Portion Weight Milligram Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432593&version=1.0"
+      }
+    },
+    "preservation_method": {
+      "description": "Text term that represents the method used to preserve the sample.\n",
+      "termDef": {
+        "cde_id": 5432521,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Tissue Sample Preservation Method Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432521&version=1.0"
+      }
+    },
+    "prior_malignancy": {
+      "description": "Text term to describe the patient's history of prior cancer diagnosis and the spatial location of any previous cancer occurrence.\n",
+      "termDef": {
+        "cde_id": 3382736,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "Prior Cancer Diagnosis Occurrence Description Text",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3382736&version=2.0"
+      }
+    },
+    "prior_treatment": {
+      "description": "A yes/no/unknown/not applicable indicator related to the administration of therapeutic agents received before the body specimen was collected.\n",
+      "termDef": {
+        "cde_id": 4231463,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Therapeutic Procedure Prior Specimen Collection Administered Yes No Unknown Not Applicable Indicator",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4231463&version=1.0"
+      }
+    },
+    "progesterone_receptor_percent_positive_ihc": {
+      "description": "Classification to represent Progesterone Receptor Positive results expressed as a percentage value.\n",
+      "termDef": {
+        "cde_id": 3128342,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Progesterone Receptor Level Cell Percentage Category",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3128342&version=1.0"
+      }
+    },
+    "progesterone_receptor_result_ihc": {
+      "description": "Text term to represent the overall result of Progresterone Receptor (PR) testing.\n",
+      "termDef": {
+        "cde_id": 2957357,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "Breast Carcinoma Progesterone Receptor Status",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2957357&version=2.0"
+      }
+    },
+    "progression_or_recurrence": {
+      "description": "Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.\n",
+      "termDef": {
+        "cde_id": 3121376,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "New Neoplasm Event Post Initial Therapy Indicator",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3121376&version=1.0"
+      }
+    },
+    "project_id": {
+      "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
+    },
+    "qc_metric_state": {
+      "description": "State classification given by FASTQC for the metric. Metric specific details about the states are available on their website.\n",
+      "termDef": {
+        "cde_id": null,
+        "cde_version": null,
+        "source": "FastQC",
+        "term": "QC Metric State",
+        "term_url": "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/"
+      }
+    },
+    "race": {
+      "description": "An arbitrary classification of a taxonomic group that is a division of a species (HARMONIZED). It usually arises as a consequence of geographical isolation within a species and is characterized by shared heredity, physical attributes and behavior, and in the case of humans, by common history, nationality, or geographic distribution. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau. (GTEx)\n",
+      "termDef": {
+        "cde_id": 2192199,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Race Category Text",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2192199&version=1.0"
+      }
+    },
+    "read_group_name": {
+      "description": "The name of the read group.\n"
+    },
+    "read_length": {
+      "description": "The length of the reads.\n"
+    },
+    "relationship_age_at_diagnosis": {
+      "description": "The age (in years) when the patient's relative was first diagnosed.\n",
+      "termDef": {
+        "cde_id": 5300571,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Relative Diagnosis Age Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5300571&version=1.0"
+      }
+    },
+    "relationship_to_proband": {
+      "description": "The subgroup that describes the state of connectedness between members of the unit of society organized around kinship ties.\n",
+      "termDef": {
+        "cde_id": 2690165,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "Family Member Relationship Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2690165&version=2.0"
+      }
+    },
+    "relationship_type": {
+      "description": "The subgroup that describes the state of connectedness between members of the unit of society organized around kinship ties.\n",
+      "termDef": {
+        "cde_id": 2690165,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "Family Member Relationship Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2690165&version=2.0"
+      }
+    },
+    "relative_with_cancer_history": {
+      "description": "Indicator to signify whether or not an individual's biological relative has been diagnosed with another type of cancer.\n",
+      "termDef": {
+        "cde_id": 3901752,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Other Cancer Biological Relative History Indicator",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3901752&version=1.0"
+      }
+    },
+    "residual_disease": {
+      "description": "Text terms to describe the status of a tissue margin following surgical resection.\n",
+      "termDef": {
+        "cde_id": 2608702,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Surgical Margin Resection Status",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2608702&version=1.0"
+      }
+    },
+    "sample_type": {
+      "description": "Text term to describe the source of a biospecimen used for a laboratory test.\n",
+      "termDef": {
+        "cde_id": 3111302,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "Specimen Type Collection Biospecimen Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3111302&version=2.0"
+      }
+    },
+    "sample_type_id": {
+      "description": "The accompanying sample type id for the sample type.\n"
+    },
+    "section_location": {
+      "description": "Tissue source of the slide.\n"
+    },
+    "sequencing_center": {
+      "description": "Name of the center that provided the sequence files.\n"
+    },
+    "shortest_dimension": {
+      "description": "Numeric value that represents the shortest dimension of the sample, measured in millimeters.\n",
+      "termDef": {
+        "cde_id": 5432603,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Tissue Sample Short Dimension Millimeter Measurement",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432603&version=1.0"
+      }
+    },
+    "site_of_resection_or_biopsy": {
+      "description": "The third edition of the International Classification of Diseases for Oncology, published in 2000, used principally in tumor and cancer registries for coding the site (topography) and the histology (morphology) of neoplasms. The description of an anatomical region or of a body part. Named locations of, or within, the body. A system of numbered categories for representation of data.\n",
+      "termDef": {
+        "cde_id": 3226281,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "International Classification of Diseases for Oncology, Third Edition ICD-O-3 Site Code",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3226281&version=1.0"
+      }
+    },
+    "size_selection_range": {
+      "description": "Range of size selection.\n"
+    },
+    "smoking_history": {
+      "description": "Category describing current smoking status and smoking history as self-reported by a patient.\n",
+      "termDef": {
+        "cde_id": 2181650,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Smoking History",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2181650&version=1.0"
+      }
+    },
+    "smoking_intensity": {
+      "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20\n",
+      "termDef": {
+        "cde_id": 2955385,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Person Cigarette Smoking History Pack Year Value",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2955385&version=1.0"
+      }
+    },
+    "source_center": {
+      "description": "Name of the center that provided the item.\n"
+    },
+    "spectrophotometer_method": {
+      "description": "Name of the method used to determine the concentration of purified nucleic acid within a solution.\n",
+      "termDef": {
+        "cde_id": 3008378,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Purification Nucleic Acid Solution Concentration Determination Method Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3008378&version=1.0"
+      }
+    },
+    "spike_ins_concentration": {
+      "description": "Spike in concentration.\n"
+    },
+    "spike_ins_fasta": {
+      "description": "Name of the FASTA file that contains the spike-in sequences.\n"
+    },
+    "state": {
+      "description": "The current state of the object.\n"
+    },
+    "target_capture_kit_catalog_number": {
+      "description": "Catalog of Target Capture Kit.\n"
+    },
+    "target_capture_kit_name": {
+      "description": "Name of Target Capture Kit.\n"
+    },
+    "target_capture_kit_target_region": {
+      "description": "Target Capture Kit BED file.\n"
+    },
+    "target_capture_kit_vendor": {
+      "description": "Vendor of Target Capture Kit.\n"
+    },
+    "target_capture_kit_version": {
+      "description": "Version of Target Capture Kit.\n"
+    },
+    "therapeutic_agents": {
+      "description": "Text identification of the individual agent(s) used as part of a prior treatment regimen.\n",
+      "termDef": {
+        "cde_id": 2975232,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Prior Therapy Regimen Text",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2975232&version=1.0"
+      }
+    },
+    "time_between_clamping_and_freezing": {
+      "description": "Numeric representation of the elapsed time between the surgical clamping of blood supply and freezing of the sample, measured in minutes.\n",
+      "termDef": {
+        "cde_id": 5432611,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Tissue Sample Clamping and Freezing Elapsed Minute Time",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432611&version=1.0"
+      }
+    },
+    "time_between_excision_and_freezing": {
+      "description": "Numeric representation of the elapsed time between the excision and freezing of the sample, measured in minutes.\n",
+      "termDef": {
+        "cde_id": 5432612,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Tissue Sample Excision and Freezing Elapsed Minute Time",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432612&version=1.0"
+      }
+    },
+    "tissue_or_organ_of_origin": {
+      "description": "Text term that describes the anatomic site of the tumor or disease.\n",
+      "termDef": {
+        "cde_id": 3427536,
+        "cde_version": 3.0,
+        "source": "caDSR",
+        "term": "Tumor Disease Anatomic Site",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3427536&version=3.0"
+      }
+    },
+    "tissue_type": {
+      "description": "Text term that represents a description of the kind of tissue collected with respect to disease status or proximity to tumor tissue.\n",
+      "termDef": {
+        "cde_id": 5432687,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Tissue Sample Description Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432687&version=1.0"
+      }
+    },
+    "to_trim_adapter_sequence": {
+      "description": "Does the user suggest adapter trimming?\n"
+    },
+    "tobacco_smoking_onset_year": {
+      "description": "The year in which the participant began smoking.\n",
+      "termDef": {
+        "cde_id": 2228604,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Started Smoking Year",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2228604&version=1.0"
+      }
+    },
+    "tobacco_smoking_quit_year": {
+      "description": "The year in which the participant quit smoking.\n",
+      "termDef": {
+        "cde_id": 2228610,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Stopped Smoking Year",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2228610&version=1.0"
+      }
+    },
+    "tobacco_smoking_status": {
+      "description": "Category describing current smoking status and smoking history as self-reported by a patient.\n",
+      "termDef": {
+        "cde_id": 2181650,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Patient Smoking History Category",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2181650&version=1.0"
+      }
+    },
+    "total_sequences": {
+      "description": "A count of the total number of sequences processed.\n",
+      "termDef": {
+        "cde_id": null,
+        "cde_version": null,
+        "source": "FastQC",
+        "term": "Total Sequences",
+        "term_url": "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/1%20Basic%20Statistics.html"
+      }
+    },
+    "treatment_anatomic_site": {
+      "description": "The anatomic site or field targeted by a treatment regimen or single agent therapy.\n",
+      "termDef": {
+        "cde_id": null,
+        "cde_version": null,
+        "source": null,
+        "term": "Treatment Anatomic Site",
+        "term_url": null
+      }
+    },
+    "treatment_intent_type": {
+      "description": "Text term to identify the reason for the administration of a treatment regimen. [Manually-curated]\n",
+      "termDef": {
+        "cde_id": 2793511,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Treatment Regimen Intent Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2793511&version=1.0"
+      }
+    },
+    "treatment_or_therapy": {
+      "description": "A yes/no/unknown/not applicable indicator related to the administration of therapeutic agents received before the body specimen was collected.\n",
+      "termDef": {
+        "cde_id": 4231463,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Therapeutic Procedure Prior Specimen Collection Administered Yes No Unknown Not Applicable Indicator",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4231463&version=1.0"
+      }
+    },
+    "treatment_outcome": {
+      "description": "Text term that describes the patient\u00bfs final outcome after the treatment was administered.\n",
+      "termDef": {
+        "cde_id": 5102383,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Treatment Outcome Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5102383&version=1.0"
+      }
+    },
+    "treatment_type": {
+      "description": "Text term that describes the kind of treatment administered.\n",
+      "termDef": {
+        "cde_id": 5102381,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Treatment Method Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5102381&version=1.0"
+      }
+    },
+    "tumor_code": {
+      "description": "Diagnostic tumor code of the tissue sample source.\n"
+    },
+    "tumor_code_id": {
+      "description": "BCR-defined id code for the tumor sample.\n"
+    },
+    "tumor_descriptor": {
+      "description": "Text that describes the kind of disease present in the tumor specimen as related to a specific timepoint.\n",
+      "termDef": {
+        "cde_id": 3288124,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Tumor Tissue Disease Description Type",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3288124&version=1.0"
+      }
+    },
+    "tumor_grade": {
+      "description": "Numeric value to express the degree of abnormality of cancer cells, a measure of differentiation and aggressiveness.\n",
+      "termDef": {
+        "cde_id": 2785839,
+        "cde_version": 2.0,
+        "source": "caDSR",
+        "term": "Neoplasm Histologic Grade",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2785839&version=2.0"
+      }
+    },
+    "tumor_stage": {
+      "description": "The extent of a cancer in the body. Staging is usually based on the size of the tumor, whether lymph nodes contain cancer, and whether the cancer has spread from the original site to other parts of the body. The accepted values for tumor_stage depend on the tumor site, type, and accepted staging system. These items should accompany the tumor_stage value as associated metadata.\n",
+      "termDef": {
+        "cde_id": "C16899",
+        "cde_version": null,
+        "source": "NCIt",
+        "term": "Tumor Stage",
+        "term_url": "https://ncit.nci.nih.gov/ncitbrowser/pages/concept_details.jsf?dictionary=NCI%20Thesaurus&code=C16899"
+      }
+    },
+    "vascular_invasion_present": {
+      "description": "The yes/no indicator to ask if large vessel or venous invasion was detected by surgery or presence in a tumor specimen.\n",
+      "termDef": {
+        "cde_id": 64358,
+        "cde_version": 3.0,
+        "source": "caDSR",
+        "term": "Tumor Vascular Invasion Ind-3",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=64358&version=3.0"
+      }
+    },
+    "vital_status": {
+      "description": "The survival state of the person registered on the protocol.\n",
+      "termDef": {
+        "cde_id": 5,
+        "cde_version": 5.0,
+        "source": "caDSR",
+        "term": "Patient Vital Status",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5&version=5.0"
+      }
+    },
+    "weight": {
+      "description": "The weight of the patient measured in lbs (HARMONIZED).\n",
+      "termDef": {
+        "cde_id": 651,
+        "cde_version": 4.0,
+        "source": "caDSR",
+        "term": "Patient Weight Measurement",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=651&version=4.0"
+      }
+    },
+    "well_number": {
+      "description": "Numeric value that represents the the well location within a plate for the analyte or aliquot from the sample.\n",
+      "termDef": {
+        "cde_id": 5432613,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Biospecimen Analyte or Aliquot Plate Well Number",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432613&version=1.0"
+      }
+    },
+    "workflow_type": {
+      "description": "Generic name for the workflow used to analyze a data set.\n"
+    },
+    "year_of_birth": {
+      "description": "Numeric value to represent the calendar year in which an individual was born.\n",
+      "termDef": {
+        "cde_id": 2896954,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Year Birth Date Number",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2896954&version=1.0"
+      }
+    },
+    "year_of_death": {
+      "description": "Numeric value to represent the year of the death of an individual.\n",
+      "termDef": {
+        "cde_id": 2897030,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Year Death Number",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897030&version=1.0"
+      }
+    },
+    "year_of_diagnosis": {
+      "description": "Numeric value to represent the year of an individual's initial pathologic diagnosis of cancer.\n",
+      "termDef": {
+        "cde_id": 2896960,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Year of initial pathologic diagnosis",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2896960&version=1.0"
+      }
+    },
+    "years_smoked": {
+      "description": "Numeric value (or unknown) to represent the number of years a person has been smoking (HARMONIZED). If the number of years is greater than 89, see 'years_smoked_gt89'.\n",
+      "termDef": {
+        "cde_id": 3137957,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Person Smoking Duration Year Count",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3137957&version=1.0"
+      }
+    },
+    "years_smoked_gt89": {
+      "description": "Indicate whether the numeric value to represent the number of years a person has been smoking (HARMONIZED) is greater than 89 years.\n",
+      "termDef": {
+        "cde_id": 3137957,
+        "cde_version": 1.0,
+        "source": "caDSR",
+        "term": "Person Smoking Duration Year Count",
+        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3137957&version=1.0"
+      }
+    }
+  },
+  "family_member_history.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "Information about patient's relatives, relevant for patient. Significant health conditions for a person related to the patient relevant in the context of care for the patient. [See https://hl7.org/fhir/R5/FamilyMemberHistory.html]",
+    "id": "family_member_history",
+    "links": [
+      {
+        "backref": "family_member_history",
+        "label": "FamilyMemberHistory_patient_Patient_family_member_history",
+        "multiplicity": "many_to_many",
+        "name": "patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "reason_family_member_history",
+        "label": "FamilyMemberHistory_reason_Condition_reason_family_member_history",
+        "multiplicity": "many_to_many",
+        "name": "reason_Condition",
+        "required": false,
+        "target_type": "condition"
+      },
+      {
+        "backref": "reason_family_member_history",
+        "label": "FamilyMemberHistory_reason_Observation_reason_family_member_history",
+        "multiplicity": "many_to_many",
+        "name": "reason_Observation",
+        "required": false,
+        "target_type": "observation"
+      },
+      {
+        "backref": "reason_family_member_history",
+        "label": "FamilyMemberHistory_reason_DiagnosticReport_reason_family_member_history",
+        "multiplicity": "many_to_many",
+        "name": "reason_DiagnosticReport",
+        "required": false,
+        "target_type": "diagnostic_report"
+      },
+      {
+        "backref": "reason_family_member_history",
+        "label": "FamilyMemberHistory_reason_DocumentReference_reason_family_member_history",
+        "multiplicity": "many_to_many",
+        "name": "reason_DocumentReference",
+        "required": false,
+        "target_type": "document_reference"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "ageAge": {
+        "description": "[Text representation of Age] The age of the relative at the time the family member history is recorded.",
+        "element_property": true,
+        "one_of_many": "age",
+        "one_of_many_required": false,
+        "title": "(approximate) age",
+        "type": "string"
+      },
+      "ageRange": {
+        "description": "[Text representation of Range] The age of the relative at the time the family member history is recorded.",
+        "element_property": true,
+        "one_of_many": "age",
+        "one_of_many_required": false,
+        "title": "(approximate) age",
+        "type": "string"
+      },
+      "ageString": {
+        "description": "The age of the relative at the time the family member history is recorded.",
+        "element_property": true,
+        "one_of_many": "age",
+        "one_of_many_required": false,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "(approximate) age",
+        "type": "string"
+      },
+      "bornDate": {
+        "description": "The actual or approximate date of birth of the relative.",
+        "element_property": true,
+        "format": "date",
+        "one_of_many": "born",
+        "one_of_many_required": false,
+        "title": "(approximate) date of birth",
+        "type": "string"
+      },
+      "bornPeriod": {
+        "description": "[Text representation of Period] The actual or approximate date of birth of the relative.",
+        "element_property": true,
+        "one_of_many": "born",
+        "one_of_many_required": false,
+        "title": "(approximate) date of birth",
+        "type": "string"
+      },
+      "bornString": {
+        "description": "The actual or approximate date of birth of the relative.",
+        "element_property": true,
+        "one_of_many": "born",
+        "one_of_many_required": false,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "(approximate) date of birth",
+        "type": "string"
+      },
+      "condition": {
+        "description": "[Text representation of FamilyMemberHistoryCondition] The significant Conditions (or condition) that the family member had. This is a repeating section to allow a system to represent more than one condition per resource, though there is nothing stopping multiple resources - one per condition.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Condition that the related person had",
+        "type": "array"
+      },
+      "dataAbsentReason": {
+        "binding_description": "Codes describing the reason why a family member's history is not available.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/history-absent-reason",
+        "binding_version": null,
+        "description": "text representation. Describes why the family member's history is not available.",
+        "element_property": true,
+        "term": {
+          "description": "Codes describing the reason why a family member's history is not available.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/history-absent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/history-absent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/history-absent-reason"
+          }
+        },
+        "title": "subject-unknown | withheld | unable-to-obtain | deferred",
+        "type": "string"
+      },
+      "dataAbsentReason_coding": {
+        "binding_description": "Codes describing the reason why a family member's history is not available.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/history-absent-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes why the family member's history is not available.",
+        "element_property": true,
+        "term": {
+          "description": "Codes describing the reason why a family member's history is not available.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/history-absent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/history-absent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/history-absent-reason"
+          }
+        },
+        "title": "subject-unknown | withheld | unable-to-obtain | deferred",
+        "type": "string"
+      },
+      "dataAbsentReason_text": {
+        "binding_description": "Codes describing the reason why a family member's history is not available.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/history-absent-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes why the family member's history is not available.",
+        "element_property": true,
+        "term": {
+          "description": "Codes describing the reason why a family member's history is not available.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/history-absent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/history-absent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/history-absent-reason"
+          }
+        },
+        "title": "subject-unknown | withheld | unable-to-obtain | deferred",
+        "type": "string"
+      },
+      "date": {
+        "description": "The date (and possibly time) when the family member history was recorded or last updated.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "When history was recorded or last updated",
+        "type": "string"
+      },
+      "deceasedAge": {
+        "description": "[Text representation of Age] Deceased flag or the actual or approximate age of the relative at the time of death for the family member history record.",
+        "element_property": true,
+        "one_of_many": "deceased",
+        "one_of_many_required": false,
+        "title": "Dead? How old/when?",
+        "type": "string"
+      },
+      "deceasedBoolean": {
+        "description": "Deceased flag or the actual or approximate age of the relative at the time of death for the family member history record.",
+        "element_property": true,
+        "one_of_many": "deceased",
+        "one_of_many_required": false,
+        "title": "Dead? How old/when?",
+        "type": "boolean"
+      },
+      "deceasedDate": {
+        "description": "Deceased flag or the actual or approximate age of the relative at the time of death for the family member history record.",
+        "element_property": true,
+        "format": "date",
+        "one_of_many": "deceased",
+        "one_of_many_required": false,
+        "title": "Dead? How old/when?",
+        "type": "string"
+      },
+      "deceasedRange": {
+        "description": "[Text representation of Range] Deceased flag or the actual or approximate age of the relative at the time of death for the family member history record.",
+        "element_property": true,
+        "one_of_many": "deceased",
+        "one_of_many_required": false,
+        "title": "Dead? How old/when?",
+        "type": "string"
+      },
+      "deceasedString": {
+        "description": "Deceased flag or the actual or approximate age of the relative at the time of death for the family member history record.",
+        "element_property": true,
+        "one_of_many": "deceased",
+        "one_of_many_required": false,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "Dead? How old/when?",
+        "type": "string"
+      },
+      "estimatedAge": {
+        "description": "If true, indicates that the age value specified is an estimated value.",
+        "element_property": true,
+        "title": "Age is estimated?",
+        "type": "boolean"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Business identifiers assigned to this family member history by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Id(s) for this record",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Business identifiers assigned to this family member history by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Id(s) for this record",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Business identifiers assigned to this family member history by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Id(s) for this record",
+        "type": "array"
+      },
+      "instantiatesCanonical": {
+        "description": "The URL pointing to a FHIR-defined protocol, guideline, orderset or other definition that is adhered to in whole or in part by this FamilyMemberHistory.",
+        "element_property": true,
+        "enum_reference_types": [
+          "PlanDefinition",
+          "Questionnaire",
+          "ActivityDefinition",
+          "Measure",
+          "OperationDefinition"
+        ],
+        "items": {
+          "pattern": "\\S*",
+          "type": "string"
+        },
+        "title": "Instantiates FHIR protocol or definition",
+        "type": "array"
+      },
+      "instantiatesUri": {
+        "description": "The URL pointing to an externally maintained protocol, guideline, orderset or other definition that is adhered to in whole or in part by this FamilyMemberHistory.",
+        "element_property": true,
+        "items": {
+          "pattern": "\\S*",
+          "type": "string"
+        },
+        "title": "Instantiates external protocol or definition",
+        "type": "array"
+      },
+      "name": {
+        "description": "This will either be a name or a description; e.g. \"Aunt Susan\", \"my cousin with the red hair\".",
+        "element_property": true,
+        "pattern": "[ \\r\\n\\t\\S]+",
+        "title": "The family member described",
+        "type": "string"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] This property allows a non condition-specific note to the made about the related person. Ideally, the note would be in the condition property, but this is not always possible.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "General note about related person",
+        "type": "array"
+      },
+      "participant": {
+        "description": "[Text representation of FamilyMemberHistoryParticipant] Indicates who or what participated in the activities related to the family member history and how they were involved.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Who or what participated in the activities related to the family member history and how they were involved",
+        "type": "array"
+      },
+      "patient": {
+        "backref": "family_member_history",
+        "description": "[Text representation of Reference] The person who this history concerns.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient"
+        ],
+        "title": "Patient history is about",
+        "type": "string"
+      },
+      "procedure": {
+        "description": "[Text representation of FamilyMemberHistoryProcedure] The significant Procedures (or procedure) that the family member had. This is a repeating section to allow a system to represent more than one procedure per resource, though there is nothing stopping multiple resources - one per procedure.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Procedures that the related person had",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "reason": {
+        "backref": "reason_family_member_history",
+        "binding_description": "Codes indicating why the family member history was done.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/clinical-findings",
+        "binding_version": null,
+        "description": "text representation. Describes why the family member history occurred in coded or textual form, or Indicates a Condition, Observation, AllergyIntolerance, or QuestionnaireResponse that justifies this family member history event.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "AllergyIntolerance",
+          "QuestionnaireResponse",
+          "DiagnosticReport",
+          "DocumentReference"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes indicating why the family member history was done.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "term_url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+          }
+        },
+        "title": "Why was family member history performed?",
+        "type": "array"
+      },
+      "reason_coding": {
+        "backref": "reason_family_member_history",
+        "binding_description": "Codes indicating why the family member history was done.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/clinical-findings",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes why the family member history occurred in coded or textual form, or Indicates a Condition, Observation, AllergyIntolerance, or QuestionnaireResponse that justifies this family member history event.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "AllergyIntolerance",
+          "QuestionnaireResponse",
+          "DiagnosticReport",
+          "DocumentReference"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes indicating why the family member history was done.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "term_url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+          }
+        },
+        "title": "Why was family member history performed?",
+        "type": "array"
+      },
+      "reason_text": {
+        "backref": "reason_family_member_history",
+        "binding_description": "Codes indicating why the family member history was done.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/clinical-findings",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes why the family member history occurred in coded or textual form, or Indicates a Condition, Observation, AllergyIntolerance, or QuestionnaireResponse that justifies this family member history event.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "AllergyIntolerance",
+          "QuestionnaireResponse",
+          "DiagnosticReport",
+          "DocumentReference"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes indicating why the family member history was done.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/clinical-findings",
+            "term_url": "http://hl7.org/fhir/ValueSet/clinical-findings"
+          }
+        },
+        "title": "Why was family member history performed?",
+        "type": "array"
+      },
+      "relationship": {
+        "binding_description": "The nature of the relationship between the patient and the related person being described in the family member history.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-FamilyMember",
+        "binding_version": null,
+        "description": "text representation. The type of relationship this person has to the patient (father, mother, brother etc.).",
+        "element_property": true,
+        "term": {
+          "description": "The nature of the relationship between the patient and the related person being described in the family member history.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-FamilyMember",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v3-FamilyMember",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-FamilyMember"
+          }
+        },
+        "title": "Relationship to the subject",
+        "type": "string"
+      },
+      "relationship_coding": {
+        "binding_description": "The nature of the relationship between the patient and the related person being described in the family member history.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-FamilyMember",
+        "binding_version": null,
+        "description": "[system#code representation.] The type of relationship this person has to the patient (father, mother, brother etc.).",
+        "element_property": true,
+        "term": {
+          "description": "The nature of the relationship between the patient and the related person being described in the family member history.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-FamilyMember",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v3-FamilyMember",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-FamilyMember"
+          }
+        },
+        "title": "Relationship to the subject",
+        "type": "string"
+      },
+      "relationship_text": {
+        "binding_description": "The nature of the relationship between the patient and the related person being described in the family member history.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v3-FamilyMember",
+        "binding_version": null,
+        "description": "[system#code representation.] The type of relationship this person has to the patient (father, mother, brother etc.).",
+        "element_property": true,
+        "term": {
+          "description": "The nature of the relationship between the patient and the related person being described in the family member history.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v3-FamilyMember",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v3-FamilyMember",
+            "term_url": "http://terminology.hl7.org/ValueSet/v3-FamilyMember"
+          }
+        },
+        "title": "Relationship to the subject",
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "FamilyMemberHistory",
+        "default": "FamilyMemberHistory",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "sex": {
+        "binding_description": "Codes describing the sex assigned at birth as documented on the birth registration.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/administrative-gender",
+        "binding_version": null,
+        "description": "text representation. The birth sex of the family member.",
+        "element_property": true,
+        "term": {
+          "description": "Codes describing the sex assigned at birth as documented on the birth registration.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/administrative-gender",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/administrative-gender",
+            "term_url": "http://hl7.org/fhir/ValueSet/administrative-gender"
+          }
+        },
+        "title": "male | female | other | unknown",
+        "type": "string"
+      },
+      "sex_coding": {
+        "binding_description": "Codes describing the sex assigned at birth as documented on the birth registration.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/administrative-gender",
+        "binding_version": null,
+        "description": "[system#code representation.] The birth sex of the family member.",
+        "element_property": true,
+        "term": {
+          "description": "Codes describing the sex assigned at birth as documented on the birth registration.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/administrative-gender",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/administrative-gender",
+            "term_url": "http://hl7.org/fhir/ValueSet/administrative-gender"
+          }
+        },
+        "title": "male | female | other | unknown",
+        "type": "string"
+      },
+      "sex_text": {
+        "binding_description": "Codes describing the sex assigned at birth as documented on the birth registration.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/administrative-gender",
+        "binding_version": null,
+        "description": "[system#code representation.] The birth sex of the family member.",
+        "element_property": true,
+        "term": {
+          "description": "Codes describing the sex assigned at birth as documented on the birth registration.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/administrative-gender",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://hl7.org/fhir/ValueSet/administrative-gender",
+            "term_url": "http://hl7.org/fhir/ValueSet/administrative-gender"
+          }
+        },
+        "title": "male | female | other | unknown",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "A code that identifies the status of the family history record.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/history-status",
+        "binding_version": "5.0.0",
+        "description": "A code specifying the status of the record of the family history of a specific family member.",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "partial",
+          "completed",
+          "entered-in-error",
+          "health-unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "partial | completed | entered-in-error | health-unknown",
+        "type": "string"
+      }
+    },
+    "title": "FamilyMemberHistory",
+    "type": "object"
+  },
+  "body_structure.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "Specific and identified anatomical structure. Record details about an anatomical structure.  This resource may be used when a coded concept does not provide the necessary detail needed for the use case. [See https://hl7.org/fhir/R5/BodyStructure.html]",
+    "id": "body_structure",
+    "links": [
+      {
+        "backref": "body_structure",
+        "label": "BodyStructure_patient_Patient_body_structure",
+        "multiplicity": "many_to_many",
+        "name": "patient",
+        "required": false,
+        "target_type": "patient"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "active": {
+        "description": "Whether this body site is in active use.",
+        "element_property": true,
+        "title": "Whether this record is in active use",
+        "type": "boolean"
+      },
+      "description": {
+        "description": "A summary, characterization or explanation of the body structure.",
+        "element_property": true,
+        "pattern": "\\s*(\\S|\\s)*",
+        "title": "Text description",
+        "type": "string"
+      },
+      "excludedStructure": {
+        "description": "[Text representation of BodyStructureIncludedStructure] The anatomical location(s) or region(s) not occupied or represented by the specimen, lesion, or body structure.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Excluded anatomic locations(s)",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Identifier for this instance of the anatomical structure.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Bodystructure identifier",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Identifier for this instance of the anatomical structure.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Bodystructure identifier",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Identifier for this instance of the anatomical structure.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Bodystructure identifier",
+        "type": "array"
+      },
+      "image": {
+        "description": "[Text representation of Attachment] Image or images used to identify a location.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Attached images",
+        "type": "array"
+      },
+      "includedStructure": {
+        "description": "[Text representation of BodyStructureIncludedStructure] The anatomical location(s) or region(s) of the specimen, lesion, or body structure.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Included anatomic location(s)",
+        "type": "array"
+      },
+      "morphology": {
+        "binding_description": "Codes describing anatomic morphology.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/bodystructure-code",
+        "binding_version": null,
+        "description": "text representation. The kind of structure being represented by the body structure at `BodyStructure.location`.  This can define both normal and abnormal morphologies.",
+        "element_property": true,
+        "term": {
+          "description": "Codes describing anatomic morphology.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/bodystructure-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/bodystructure-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/bodystructure-code"
+          }
+        },
+        "title": "Kind of Structure",
+        "type": "string"
+      },
+      "morphology_coding": {
+        "binding_description": "Codes describing anatomic morphology.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/bodystructure-code",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind of structure being represented by the body structure at `BodyStructure.location`.  This can define both normal and abnormal morphologies.",
+        "element_property": true,
+        "term": {
+          "description": "Codes describing anatomic morphology.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/bodystructure-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/bodystructure-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/bodystructure-code"
+          }
+        },
+        "title": "Kind of Structure",
+        "type": "string"
+      },
+      "morphology_text": {
+        "binding_description": "Codes describing anatomic morphology.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/bodystructure-code",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind of structure being represented by the body structure at `BodyStructure.location`.  This can define both normal and abnormal morphologies.",
+        "element_property": true,
+        "term": {
+          "description": "Codes describing anatomic morphology.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/bodystructure-code",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/bodystructure-code",
+            "term_url": "http://hl7.org/fhir/ValueSet/bodystructure-code"
+          }
+        },
+        "title": "Kind of Structure",
+        "type": "string"
+      },
+      "patient": {
+        "backref": "body_structure",
+        "description": "[Text representation of Reference] The person to which the body site belongs.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient"
+        ],
+        "title": "Who this is about",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "BodyStructure",
+        "default": "BodyStructure",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      }
+    },
+    "title": "BodyStructure",
+    "type": "object"
+  },
+  "specimen.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Biospecimen",
+    "description": "Sample for analysis. A sample to be used for analysis. [See https://hl7.org/fhir/R5/Specimen.html]",
+    "id": "specimen",
+    "links": [
+      {
+        "backref": "specimen",
+        "label": "Specimen_subject_Patient_specimen",
+        "multiplicity": "many_to_many",
+        "name": "subject_Patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "specimen",
+        "label": "Specimen_subject_Substance_specimen",
+        "multiplicity": "many_to_many",
+        "name": "subject_Substance",
+        "required": false,
+        "target_type": "substance"
+      },
+      {
+        "backref": "specimen",
+        "label": "Specimen_subject_Location_specimen",
+        "multiplicity": "many_to_many",
+        "name": "subject_Location",
+        "required": false,
+        "target_type": "location"
+      },
+      {
+        "backref": "parent_specimen",
+        "label": "Specimen_parent_Specimen_parent_specimen",
+        "multiplicity": "many_to_many",
+        "name": "parent",
+        "required": false,
+        "target_type": "specimen"
+      },
+      {
+        "backref": "specimen",
+        "label": "Specimen_bodySite_BodyStructure_specimen",
+        "multiplicity": "many_to_many",
+        "name": "bodySite",
+        "required": false,
+        "target_type": "body_structure"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "accessionIdentifier": {
+        "description": "[Text representation of Identifier] The identifier assigned by the lab when accessioning specimen(s). This is not necessarily the same as the specimen identifier, depending on local lab procedures.",
+        "element_property": true,
+        "title": "Identifier assigned by the lab",
+        "type": "string"
+      },
+      "bodySite": {
+        "backref": "specimen",
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "text representation. Anatomical location from which the specimen was collected (if subject is a patient). This is the target site.  This element is not used for environmental specimens.",
+        "element_property": true,
+        "enum_reference_types": [
+          "BodyStructure"
+        ],
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Anatomical collection site",
+        "type": "string"
+      },
+      "bodySite_coding": {
+        "backref": "specimen",
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] Anatomical location from which the specimen was collected (if subject is a patient). This is the target site.  This element is not used for environmental specimens.",
+        "element_property": true,
+        "enum_reference_types": [
+          "BodyStructure"
+        ],
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Anatomical collection site",
+        "type": "string"
+      },
+      "bodySite_text": {
+        "backref": "specimen",
+        "binding_description": "SNOMED CT Body site concepts",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/body-site",
+        "binding_version": null,
+        "description": "[system#code representation.] Anatomical location from which the specimen was collected (if subject is a patient). This is the target site.  This element is not used for environmental specimens.",
+        "element_property": true,
+        "enum_reference_types": [
+          "BodyStructure"
+        ],
+        "term": {
+          "description": "SNOMED CT Body site concepts",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/body-site",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/body-site",
+            "term_url": "http://hl7.org/fhir/ValueSet/body-site"
+          }
+        },
+        "title": "Anatomical collection site",
+        "type": "string"
+      },
+      "collection": {
+        "description": "[Text representation of SpecimenCollection] Details concerning the specimen collection.",
+        "element_property": true,
+        "title": "Collection details",
+        "type": "string"
+      },
+      "combined": {
+        "binding_description": "Codes for the combined status of a specimen.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/specimen-combined",
+        "binding_version": "5.0.0",
+        "description": "This element signifies if the specimen is part of a group or pooled.",
+        "element_property": true,
+        "enum_values": [
+          "grouped",
+          "pooled"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "grouped | pooled",
+        "type": "string"
+      },
+      "condition": {
+        "binding_description": "Codes describing the state of the specimen.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v2-0493",
+        "binding_version": null,
+        "description": "text representation. A mode or state of being that describes the nature of the specimen.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing the state of the specimen.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v2-0493",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://terminology.hl7.org/ValueSet/v2-0493",
+            "term_url": "http://terminology.hl7.org/ValueSet/v2-0493"
+          }
+        },
+        "title": "State of the specimen",
+        "type": "array"
+      },
+      "condition_coding": {
+        "binding_description": "Codes describing the state of the specimen.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v2-0493",
+        "binding_version": null,
+        "description": "[system#code representation.] A mode or state of being that describes the nature of the specimen.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing the state of the specimen.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v2-0493",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://terminology.hl7.org/ValueSet/v2-0493",
+            "term_url": "http://terminology.hl7.org/ValueSet/v2-0493"
+          }
+        },
+        "title": "State of the specimen",
+        "type": "array"
+      },
+      "condition_text": {
+        "binding_description": "Codes describing the state of the specimen.",
+        "binding_strength": "extensible",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v2-0493",
+        "binding_version": null,
+        "description": "[system#code representation.] A mode or state of being that describes the nature of the specimen.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing the state of the specimen.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v2-0493",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "extensible",
+            "term": "http://terminology.hl7.org/ValueSet/v2-0493",
+            "term_url": "http://terminology.hl7.org/ValueSet/v2-0493"
+          }
+        },
+        "title": "State of the specimen",
+        "type": "array"
+      },
+      "container": {
+        "description": "[Text representation of SpecimenContainer] The container holding the specimen.  The recursive nature of containers; i.e. blood in tube in tray in rack is not addressed here.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Direct container of specimen (tube/slide, etc.)",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "feature": {
+        "description": "[Text representation of SpecimenFeature] A physical feature or landmark on a specimen, highlighted for context by the collector of the specimen (e.g. surgeon), that identifies the type of feature as well as its meaning (e.g. the red ink indicating the resection margin of the right lobe of the excised prostate tissue or wire loop at radiologically suspected tumor location).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "The physical feature of a specimen",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Id for specimen.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Identifier",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Id for specimen.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Identifier",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Id for specimen.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External Identifier",
+        "type": "array"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] To communicate any details or issues about the specimen or during the specimen collection. (for example: broken vial, sent with patient, frozen).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Comments",
+        "type": "array"
+      },
+      "parent": {
+        "backref": "parent_specimen",
+        "description": "[Text representation of Reference] Reference to the parent (source) specimen which is used when the specimen was either derived from or a component of another specimen.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Specimen"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Specimen from which this specimen originated",
+        "type": "array"
+      },
+      "processing_additive": {
+        "backref": "additive_specimen_processing",
+        "description": "[Text representation of Reference] [Plucked from Specimen.processing] Material used in the processing step",
+        "element_property": true,
+        "enum_reference_types": [
+          "Substance"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Material used in the processing step",
+        "type": "array"
+      },
+      "processing_method": {
+        "binding_description": "Type indicating the technique used to process the specimen.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/specimen-processing-method",
+        "binding_version": null,
+        "description": "text representation. [Plucked from Specimen.processing] A coded value specifying the method used to process the specimen.",
+        "element_property": true,
+        "term": {
+          "description": "Type indicating the technique used to process the specimen.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/specimen-processing-method",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/specimen-processing-method",
+            "term_url": "http://hl7.org/fhir/ValueSet/specimen-processing-method"
+          }
+        },
+        "title": "Indicates the treatment step  applied to the specimen",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "receivedTime": {
+        "description": "Time when specimen is received by the testing laboratory for processing or testing.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "The time when specimen is received by the testing laboratory",
+        "type": "string"
+      },
+      "request": {
+        "backref": "request_specimen",
+        "description": "[Text representation of Reference] Details concerning a service request that required a specimen to be collected.",
+        "element_property": true,
+        "enum_reference_types": [
+          "ServiceRequest"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Why the specimen was collected",
+        "type": "array"
+      },
+      "resourceType": {
+        "const": "Specimen",
+        "default": "Specimen",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "role": {
+        "binding_description": "Codes describing specimen role.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/specimen-role",
+        "binding_version": null,
+        "description": "text representation. The role or reason for the specimen in the testing workflow.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing specimen role.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/specimen-role",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/specimen-role",
+            "term_url": "http://hl7.org/fhir/ValueSet/specimen-role"
+          }
+        },
+        "title": "The role the specimen serves",
+        "type": "array"
+      },
+      "role_coding": {
+        "binding_description": "Codes describing specimen role.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/specimen-role",
+        "binding_version": null,
+        "description": "[system#code representation.] The role or reason for the specimen in the testing workflow.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing specimen role.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/specimen-role",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/specimen-role",
+            "term_url": "http://hl7.org/fhir/ValueSet/specimen-role"
+          }
+        },
+        "title": "The role the specimen serves",
+        "type": "array"
+      },
+      "role_text": {
+        "binding_description": "Codes describing specimen role.",
+        "binding_strength": "preferred",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/specimen-role",
+        "binding_version": null,
+        "description": "[system#code representation.] The role or reason for the specimen in the testing workflow.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "Codes describing specimen role.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/specimen-role",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "preferred",
+            "term": "http://hl7.org/fhir/ValueSet/specimen-role",
+            "term_url": "http://hl7.org/fhir/ValueSet/specimen-role"
+          }
+        },
+        "title": "The role the specimen serves",
+        "type": "array"
+      },
+      "status": {
+        "binding_description": "Codes providing the status/availability of a specimen.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/specimen-status",
+        "binding_version": "5.0.0",
+        "description": "The availability of the specimen.",
+        "element_property": true,
+        "enum_values": [
+          "available",
+          "unavailable",
+          "unsatisfactory",
+          "entered-in-error"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "available | unavailable | unsatisfactory | entered-in-error",
+        "type": "string"
+      },
+      "subject": {
+        "backref": "specimen",
+        "description": "[Text representation of Reference] Where the specimen came from. This may be from patient(s), from a location (e.g., the source of an environmental sample), or a sampling of a substance, a biologically-derived product, or a device",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Group",
+          "Device",
+          "BiologicallyDerivedProduct",
+          "Substance",
+          "Location"
+        ],
+        "title": "Where the specimen came from. This may be from patient(s), from a location (e.g., the source of an environmental sample), or a sampling of a substance, a biologically-derived product, or a device",
+        "type": "string"
+      },
+      "type": {
+        "binding_description": "The type of the specimen.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v2-0487",
+        "binding_version": null,
+        "description": "text representation. The kind of material that forms the specimen.",
+        "element_property": true,
+        "term": {
+          "description": "The type of the specimen.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v2-0487",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v2-0487",
+            "term_url": "http://terminology.hl7.org/ValueSet/v2-0487"
+          }
+        },
+        "title": "Kind of material that forms the specimen",
+        "type": "string"
+      },
+      "type_coding": {
+        "binding_description": "The type of the specimen.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v2-0487",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind of material that forms the specimen.",
+        "element_property": true,
+        "term": {
+          "description": "The type of the specimen.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v2-0487",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v2-0487",
+            "term_url": "http://terminology.hl7.org/ValueSet/v2-0487"
+          }
+        },
+        "title": "Kind of material that forms the specimen",
+        "type": "string"
+      },
+      "type_text": {
+        "binding_description": "The type of the specimen.",
+        "binding_strength": "example",
+        "binding_uri": "http://terminology.hl7.org/ValueSet/v2-0487",
+        "binding_version": null,
+        "description": "[system#code representation.] The kind of material that forms the specimen.",
+        "element_property": true,
+        "term": {
+          "description": "The type of the specimen.",
+          "termDef": {
+            "cde_id": "http://terminology.hl7.org/ValueSet/v2-0487",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://terminology.hl7.org/ValueSet/v2-0487",
+            "term_url": "http://terminology.hl7.org/ValueSet/v2-0487"
+          }
+        },
+        "title": "Kind of material that forms the specimen",
+        "type": "string"
+      }
+    },
+    "title": "Specimen",
+    "type": "object"
+  },
+  "medication_administration.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "Administration of medication to a patient. Describes the event of a patient consuming or otherwise being administered a medication.  This may be as simple as swallowing a tablet or it may be a long running infusion.  Related resources tie this event to the authorizing prescription, and the specific encounter between patient and health care practitioner. [See https://hl7.org/fhir/R5/MedicationAdministration.html]",
+    "id": "medication_administration",
+    "links": [
+      {
+        "backref": "medication_administration",
+        "label": "MedicationAdministration_subject_Patient_medication_administration",
+        "multiplicity": "many_to_many",
+        "name": "subject_Patient",
+        "required": false,
+        "target_type": "patient"
+      },
+      {
+        "backref": "medication_administration",
+        "label": "MedicationAdministration_encounter_Encounter_medication_administration",
+        "multiplicity": "many_to_many",
+        "name": "encounter",
+        "required": false,
+        "target_type": "encounter"
+      },
+      {
+        "backref": "medication_administration",
+        "label": "MedicationAdministration_medication_Medication_medication_administration",
+        "multiplicity": "many_to_many",
+        "name": "medication",
+        "required": false,
+        "target_type": "medication"
+      },
+      {
+        "backref": "partOf_medication_administration",
+        "label": "MedicationAdministration_partOf_MedicationAdministration_partOf_medication_administration",
+        "multiplicity": "many_to_many",
+        "name": "partOf_MedicationAdministration",
+        "required": false,
+        "target_type": "medication_administration"
+      },
+      {
+        "backref": "partOf_medication_administration",
+        "label": "MedicationAdministration_partOf_Procedure_partOf_medication_administration",
+        "multiplicity": "many_to_many",
+        "name": "partOf_Procedure",
+        "required": false,
+        "target_type": "procedure"
+      },
+      {
+        "backref": "reason_medication_administration",
+        "label": "MedicationAdministration_reason_Condition_reason_medication_administration",
+        "multiplicity": "many_to_many",
+        "name": "reason_Condition",
+        "required": false,
+        "target_type": "condition"
+      },
+      {
+        "backref": "reason_medication_administration",
+        "label": "MedicationAdministration_reason_Observation_reason_medication_administration",
+        "multiplicity": "many_to_many",
+        "name": "reason_Observation",
+        "required": false,
+        "target_type": "observation"
+      },
+      {
+        "backref": "reason_medication_administration",
+        "label": "MedicationAdministration_reason_DiagnosticReport_reason_medication_administration",
+        "multiplicity": "many_to_many",
+        "name": "reason_DiagnosticReport",
+        "required": false,
+        "target_type": "diagnostic_report"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "basedOn": {
+        "backref": "basedOn_medication_administration",
+        "description": "[Text representation of Reference] A plan that is fulfilled in whole or in part by this MedicationAdministration.",
+        "element_property": true,
+        "enum_reference_types": [
+          "CarePlan"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Plan this is fulfilled by this administration",
+        "type": "array"
+      },
+      "category": {
+        "binding_description": "A coded concept describing where the medication administered is expected to occur.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-admin-location",
+        "binding_version": null,
+        "description": "text representation. The type of medication administration (for example, drug classification like ATC, where meds would be administered, legal category of the medication).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A coded concept describing where the medication administered is expected to occur.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-admin-location",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-admin-location",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-admin-location"
+          }
+        },
+        "title": "Type of medication administration",
+        "type": "array"
+      },
+      "category_coding": {
+        "binding_description": "A coded concept describing where the medication administered is expected to occur.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-admin-location",
+        "binding_version": null,
+        "description": "[system#code representation.] The type of medication administration (for example, drug classification like ATC, where meds would be administered, legal category of the medication).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A coded concept describing where the medication administered is expected to occur.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-admin-location",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-admin-location",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-admin-location"
+          }
+        },
+        "title": "Type of medication administration",
+        "type": "array"
+      },
+      "category_text": {
+        "binding_description": "A coded concept describing where the medication administered is expected to occur.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-admin-location",
+        "binding_version": null,
+        "description": "[system#code representation.] The type of medication administration (for example, drug classification like ATC, where meds would be administered, legal category of the medication).",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A coded concept describing where the medication administered is expected to occur.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-admin-location",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-admin-location",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-admin-location"
+          }
+        },
+        "title": "Type of medication administration",
+        "type": "array"
+      },
+      "device": {
+        "backref": "device_medication_administration",
+        "description": "text representation. The device that is to be used for the administration of the medication (for example, PCA Pump).",
+        "element_property": true,
+        "enum_reference_types": [
+          "Device"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Device used to administer",
+        "type": "array"
+      },
+      "device_coding": {
+        "backref": "device_medication_administration",
+        "description": "[system#code representation.] The device that is to be used for the administration of the medication (for example, PCA Pump).",
+        "element_property": true,
+        "enum_reference_types": [
+          "Device"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Device used to administer",
+        "type": "array"
+      },
+      "device_text": {
+        "backref": "device_medication_administration",
+        "description": "[system#code representation.] The device that is to be used for the administration of the medication (for example, PCA Pump).",
+        "element_property": true,
+        "enum_reference_types": [
+          "Device"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Device used to administer",
+        "type": "array"
+      },
+      "dosage": {
+        "description": "[Text representation of MedicationAdministrationDosage] Describes the medication dosage information details e.g. dose, rate, site, route, etc.",
+        "element_property": true,
+        "title": "Details of how medication was taken",
+        "type": "string"
+      },
+      "encounter": {
+        "backref": "medication_administration",
+        "description": "[Text representation of Reference] The visit, admission, or other contact between patient and health care provider during which the medication administration was performed.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Encounter"
+        ],
+        "title": "Encounter administered as part of",
+        "type": "string"
+      },
+      "eventHistory": {
+        "backref": "eventHistory_medication_administration",
+        "description": "[Text representation of Reference] A summary of the events of interest that have occurred, such as when the administration was verified.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Provenance"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "A list of events of interest in the lifecycle",
+        "type": "array"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Identifiers associated with this Medication Administration that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External identifier",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Identifiers associated with this Medication Administration that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External identifier",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Identifiers associated with this Medication Administration that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "External identifier",
+        "type": "array"
+      },
+      "isSubPotent": {
+        "description": "An indication that the full dose was not administered.",
+        "element_property": true,
+        "title": "Full dose was not administered",
+        "type": "boolean"
+      },
+      "medication": {
+        "backref": "medication_administration",
+        "binding_description": "Codes identifying substance or product that can be administered.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-codes",
+        "binding_version": null,
+        "description": "text representation. Identifies the medication that was administered. This is either a link to a resource representing the details of the medication or a simple attribute carrying a code that identifies the medication from a known list of medications.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Medication"
+        ],
+        "term": {
+          "description": "Codes identifying substance or product that can be administered.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-codes"
+          }
+        },
+        "title": "What was administered",
+        "type": "string"
+      },
+      "medication_coding": {
+        "backref": "medication_administration",
+        "binding_description": "Codes identifying substance or product that can be administered.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] Identifies the medication that was administered. This is either a link to a resource representing the details of the medication or a simple attribute carrying a code that identifies the medication from a known list of medications.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Medication"
+        ],
+        "term": {
+          "description": "Codes identifying substance or product that can be administered.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-codes"
+          }
+        },
+        "title": "What was administered",
+        "type": "string"
+      },
+      "medication_text": {
+        "backref": "medication_administration",
+        "binding_description": "Codes identifying substance or product that can be administered.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] Identifies the medication that was administered. This is either a link to a resource representing the details of the medication or a simple attribute carrying a code that identifies the medication from a known list of medications.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Medication"
+        ],
+        "term": {
+          "description": "Codes identifying substance or product that can be administered.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-codes"
+          }
+        },
+        "title": "What was administered",
+        "type": "string"
+      },
+      "note": {
+        "description": "[Text representation of Annotation] Extra information about the medication administration that is not conveyed by the other attributes.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Information about the administration",
+        "type": "array"
+      },
+      "occurenceDateTime": {
+        "description": "A specific date/time or interval of time during which the administration took place (or did not take place). For many administrations, such as swallowing a tablet the use of dateTime is more appropriate.",
+        "element_property": true,
+        "format": "date-time",
+        "one_of_many": "occurence",
+        "one_of_many_required": true,
+        "title": "Specific date/time or interval of time during which the administration took place (or did not take place)",
+        "type": "string"
+      },
+      "occurencePeriod": {
+        "description": "[Text representation of Period] A specific date/time or interval of time during which the administration took place (or did not take place). For many administrations, such as swallowing a tablet the use of dateTime is more appropriate.",
+        "element_property": true,
+        "one_of_many": "occurence",
+        "one_of_many_required": true,
+        "title": "Specific date/time or interval of time during which the administration took place (or did not take place)",
+        "type": "string"
+      },
+      "occurenceTiming": {
+        "description": "[Text representation of Timing] A specific date/time or interval of time during which the administration took place (or did not take place). For many administrations, such as swallowing a tablet the use of dateTime is more appropriate.",
+        "element_property": true,
+        "one_of_many": "occurence",
+        "one_of_many_required": true,
+        "title": "Specific date/time or interval of time during which the administration took place (or did not take place)",
+        "type": "string"
+      },
+      "partOf": {
+        "backref": "partOf_medication_administration",
+        "description": "[Text representation of Reference] A larger event of which this particular event is a component or step.",
+        "element_property": true,
+        "enum_reference_types": [
+          "MedicationAdministration",
+          "Procedure",
+          "MedicationDispense"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Part of referenced event",
+        "type": "array"
+      },
+      "performer": {
+        "description": "[Text representation of MedicationAdministrationPerformer] The performer of the medication treatment.  For devices this is the device that performed the administration of the medication.  An IV Pump would be an example of a device that is performing the administration. Both the IV Pump and the practitioner that set the rate or bolus on the pump can be listed as performers.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Who or what performed the medication administration and what type of performance they did",
+        "type": "array"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "reason": {
+        "backref": "reason_medication_administration",
+        "binding_description": "A set of codes indicating the reason why the MedicationAdministration was made.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes",
+        "binding_version": null,
+        "description": "text representation. A code, Condition or observation that supports why the medication was administered.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "DiagnosticReport"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A set of codes indicating the reason why the MedicationAdministration was made.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes"
+          }
+        },
+        "title": "Concept, condition or observation that supports why the medication was administered",
+        "type": "array"
+      },
+      "reason_coding": {
+        "backref": "reason_medication_administration",
+        "binding_description": "A set of codes indicating the reason why the MedicationAdministration was made.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] A code, Condition or observation that supports why the medication was administered.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "DiagnosticReport"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A set of codes indicating the reason why the MedicationAdministration was made.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes"
+          }
+        },
+        "title": "Concept, condition or observation that supports why the medication was administered",
+        "type": "array"
+      },
+      "reason_text": {
+        "backref": "reason_medication_administration",
+        "binding_description": "A set of codes indicating the reason why the MedicationAdministration was made.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] A code, Condition or observation that supports why the medication was administered.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Condition",
+          "Observation",
+          "DiagnosticReport"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A set of codes indicating the reason why the MedicationAdministration was made.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/reason-medication-given-codes"
+          }
+        },
+        "title": "Concept, condition or observation that supports why the medication was administered",
+        "type": "array"
+      },
+      "recorded": {
+        "description": "The date the occurrence of the  MedicationAdministration was first captured in the record - potentially significantly after the occurrence of the event.",
+        "element_property": true,
+        "format": "date-time",
+        "title": "When the MedicationAdministration was first captured in the subject's record",
+        "type": "string"
+      },
+      "request": {
+        "backref": "medication_administration",
+        "description": "[Text representation of Reference] The original request, instruction or authority to perform the administration.",
+        "element_property": true,
+        "enum_reference_types": [
+          "MedicationRequest"
+        ],
+        "title": "Request administration performed against",
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "MedicationAdministration",
+        "default": "MedicationAdministration",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "A set of codes indicating the current status of a MedicationAdministration.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-admin-status",
+        "binding_version": "5.0.0",
+        "description": "Will generally be set to show that the administration has been completed.  For some long running administrations such as infusions, it is possible for an administration to be started but not completed or it may be paused while some other process is under way.",
+        "element_property": true,
+        "element_required": true,
+        "enum_values": [
+          "in-progress",
+          "not-done",
+          "on-hold",
+          "completed",
+          "entered-in-error",
+          "stopped",
+          "unknown"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "in-progress | not-done | on-hold | completed | entered-in-error | stopped | unknown",
+        "type": "string"
+      },
+      "statusReason": {
+        "binding_description": "A set of codes indicating the reason why the MedicationAdministration is negated.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes",
+        "binding_version": null,
+        "description": "text representation. A code indicating why the administration was not performed.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A set of codes indicating the reason why the MedicationAdministration is negated.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes"
+          }
+        },
+        "title": "Reason administration not performed",
+        "type": "array"
+      },
+      "statusReason_coding": {
+        "binding_description": "A set of codes indicating the reason why the MedicationAdministration is negated.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] A code indicating why the administration was not performed.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A set of codes indicating the reason why the MedicationAdministration is negated.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes"
+          }
+        },
+        "title": "Reason administration not performed",
+        "type": "array"
+      },
+      "statusReason_text": {
+        "binding_description": "A set of codes indicating the reason why the MedicationAdministration is negated.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] A code indicating why the administration was not performed.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": "A set of codes indicating the reason why the MedicationAdministration is negated.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/reason-medication-not-given-codes"
+          }
+        },
+        "title": "Reason administration not performed",
+        "type": "array"
+      },
+      "subPotentReason": {
+        "binding_description": null,
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason",
+        "binding_version": null,
+        "description": "text representation. The reason or reasons why the full dose was not administered.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason"
+          }
+        },
+        "title": "Reason full dose was not administered",
+        "type": "array"
+      },
+      "subPotentReason_coding": {
+        "binding_description": null,
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] The reason or reasons why the full dose was not administered.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason"
+          }
+        },
+        "title": "Reason full dose was not administered",
+        "type": "array"
+      },
+      "subPotentReason_text": {
+        "binding_description": null,
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason",
+        "binding_version": null,
+        "description": "[system#code representation.] The reason or reasons why the full dose was not administered.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "term": {
+          "description": null,
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason",
+            "term_url": "http://hl7.org/fhir/ValueSet/administration-subpotent-reason"
+          }
+        },
+        "title": "Reason full dose was not administered",
+        "type": "array"
+      },
+      "subject": {
+        "backref": "medication_administration",
+        "description": "[Text representation of Reference] The person or animal or group receiving the medication.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Patient",
+          "Group"
+        ],
+        "title": "Who received medication",
+        "type": "string"
+      },
+      "supportingInformation": {
+        "backref": "supportingInformation_medication_administration",
+        "description": "[Text representation of Reference] Additional information (for example, patient height and weight) that supports the administration of the medication.  This attribute can be used to provide documentation of specific characteristics of the patient present at the time of administration.  For example, if the dose says \"give \"x\" if the heartrate exceeds \"y\"\", then the heart rate can be included using this attribute.",
+        "element_property": true,
+        "enum_reference_types": [
+          "Resource"
+        ],
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional information to support administration",
+        "type": "array"
+      }
+    },
+    "title": "MedicationAdministration",
+    "type": "object"
+  },
+  "medication.yaml": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": true,
+    "category": "Clinical",
+    "description": "Definition of a Medication. This resource is primarily used for the identification and definition of a medication, including ingredients, for the purposes of prescribing, dispensing, and administering a medication as well as for making statements about medication use. [See https://hl7.org/fhir/R5/Medication.html]",
+    "id": "medication",
+    "links": [
+      {
+        "backref": "medication",
+        "label": "Medication_marketingAuthorizationHolder_Organization_medication",
+        "multiplicity": "many_to_many",
+        "name": "marketingAuthorizationHolder",
+        "required": false,
+        "target_type": "organization"
+      }
+    ],
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "batch": {
+        "description": "[Text representation of MedicationBatch] Information that only applies to packages (not products).",
+        "element_property": true,
+        "title": "Details about packaged medications",
+        "type": "string"
+      },
+      "code": {
+        "binding_description": "A coded concept that defines the type of a medication.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-codes",
+        "binding_version": null,
+        "description": "text representation. A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems.",
+        "element_property": true,
+        "term": {
+          "description": "A coded concept that defines the type of a medication.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-codes"
+          }
+        },
+        "title": "Codes that identify this medication",
+        "type": "string"
+      },
+      "code_coding": {
+        "binding_description": "A coded concept that defines the type of a medication.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems.",
+        "element_property": true,
+        "term": {
+          "description": "A coded concept that defines the type of a medication.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-codes"
+          }
+        },
+        "title": "Codes that identify this medication",
+        "type": "string"
+      },
+      "code_text": {
+        "binding_description": "A coded concept that defines the type of a medication.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems.",
+        "element_property": true,
+        "term": {
+          "description": "A coded concept that defines the type of a medication.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-codes"
+          }
+        },
+        "title": "Codes that identify this medication",
+        "type": "string"
+      },
+      "definition": {
+        "backref": "medication",
+        "description": "[Text representation of Reference] A reference to a knowledge resource that provides more information about this medication.",
+        "element_property": true,
+        "enum_reference_types": [
+          "MedicationKnowledge"
+        ],
+        "title": "Knowledge about this medication",
+        "type": "string"
+      },
+      "doseForm": {
+        "binding_description": "A coded concept defining the form of a medication.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+        "binding_version": null,
+        "description": "text representation. Describes the form of the item.  Powder; tablets; capsule.",
+        "element_property": true,
+        "term": {
+          "description": "A coded concept defining the form of a medication.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-form-codes"
+          }
+        },
+        "title": "powder | tablets | capsule +",
+        "type": "string"
+      },
+      "doseForm_coding": {
+        "binding_description": "A coded concept defining the form of a medication.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes the form of the item.  Powder; tablets; capsule.",
+        "element_property": true,
+        "term": {
+          "description": "A coded concept defining the form of a medication.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-form-codes"
+          }
+        },
+        "title": "powder | tablets | capsule +",
+        "type": "string"
+      },
+      "doseForm_text": {
+        "binding_description": "A coded concept defining the form of a medication.",
+        "binding_strength": "example",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+        "binding_version": null,
+        "description": "[system#code representation.] Describes the form of the item.  Powder; tablets; capsule.",
+        "element_property": true,
+        "term": {
+          "description": "A coded concept defining the form of a medication.",
+          "termDef": {
+            "cde_id": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+            "cde_version": null,
+            "source": "fhir",
+            "strength": "example",
+            "term": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+            "term_url": "http://hl7.org/fhir/ValueSet/medication-form-codes"
+          }
+        },
+        "title": "powder | tablets | capsule +",
+        "type": "string"
+      },
+      "extension": {
+        "description": "[Text representation of Extension] May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Additional content defined by implementations",
+        "type": "array"
+      },
+      "id": {
+        "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+        "element_property": true,
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9\\-.]+$",
+        "title": "Logical id of this artifact",
+        "type": "string"
+      },
+      "identifier": {
+        "description": "Business identifier for this medication",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifier for this medication",
+        "type": "array"
+      },
+      "identifier_coding": {
+        "description": "[system#code representation of identifier] Business identifier for this medication",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifier for this medication",
+        "type": "array"
+      },
+      "identifier_text_coding": {
+        "description": "[system#code representation of identifier.text] Business identifier for this medication",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Business identifier for this medication",
+        "type": "array"
+      },
+      "ingredient": {
+        "description": "[Text representation of MedicationIngredient] Identifies a particular constituent of interest in the product.",
+        "element_property": true,
+        "items": {
+          "type": "string"
+        },
+        "title": "Active or inactive ingredient",
+        "type": "array"
+      },
+      "marketingAuthorizationHolder": {
+        "backref": "medication",
+        "description": "[Text representation of Reference] The company or other legal entity that has authorization, from the appropriate drug regulatory authority,  to market a medicine in one or more jurisdictions.  Typically abbreviated MAH.Note:  The MAH may manufacture the product and may also contract the manufacturing of the product to one or more companies (organizations).",
+        "element_property": true,
+        "enum_reference_types": [
+          "Organization"
+        ],
+        "title": "Organization that has authorization to market medication",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "$ref": "_terms.yaml#/project_id"
+        },
+        "type": "string"
+      },
+      "resourceType": {
+        "const": "Medication",
+        "default": "Medication",
+        "description": "One of the resource types defined as part of FHIR",
+        "title": "Resource Type",
+        "type": "string"
+      },
+      "status": {
+        "binding_description": "A coded concept defining if the medication is in active use.",
+        "binding_strength": "required",
+        "binding_uri": "http://hl7.org/fhir/ValueSet/medication-status",
+        "binding_version": "5.0.0",
+        "description": "A code to indicate if the medication is in active use.",
+        "element_property": true,
+        "enum_values": [
+          "active",
+          "inactive",
+          "entered-in-error"
+        ],
+        "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
+        "title": "active | inactive | entered-in-error",
+        "type": "string"
+      },
+      "totalVolume": {
+        "description": "[Text representation of Quantity] text representation. When the specified product code does not infer a package size, this is the specific amount of drug in the product.  For example, when specifying a product that has the same strength (For example, Insulin glargine 100 unit per mL solution for injection), this attribute provides additional clarification of the package amount (For example, 3 mL, 10mL, etc.).",
+        "element_property": true,
+        "title": "When the specified product code does not infer a package size, this is the specific amount of drug in the product",
+        "type": "string"
+      },
+      "totalVolume_unit": {
+        "title": "Unit representation. When the specified product code does not infer a package size, this is the specific amount of drug in the product",
+        "type": "string"
+      },
+      "totalVolume_value": {
+        "title": "Numerical value (with implicit precision) representation. When the specified product code does not infer a package size, this is the specific amount of drug in the product",
+        "type": "number"
+      }
+    },
+    "title": "Medication",
+    "type": "object"
+  }
+}

--- a/tests/integration/data/schemas/specimen.yaml
+++ b/tests/integration/data/schemas/specimen.yaml
@@ -1,0 +1,412 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Biospecimen
+description: Sample for analysis. A sample to be used for analysis. [See https://hl7.org/fhir/R5/Specimen.html]
+id: specimen
+links:
+- backref: specimen
+  label: Specimen_subject_Patient_specimen
+  multiplicity: many_to_many
+  name: subject_Patient
+  required: false
+  target_type: patient
+- backref: specimen
+  label: Specimen_subject_Substance_specimen
+  multiplicity: many_to_many
+  name: subject_Substance
+  required: false
+  target_type: substance
+- backref: specimen
+  label: Specimen_subject_Location_specimen
+  multiplicity: many_to_many
+  name: subject_Location
+  required: false
+  target_type: location
+- backref: parent_specimen
+  label: Specimen_parent_Specimen_parent_specimen
+  multiplicity: many_to_many
+  name: parent
+  required: false
+  target_type: specimen
+- backref: specimen
+  label: Specimen_bodySite_BodyStructure_specimen
+  multiplicity: many_to_many
+  name: bodySite
+  required: false
+  target_type: body_structure
+program: '*'
+project: '*'
+properties:
+  accessionIdentifier:
+    description: '[Text representation of Identifier] The identifier assigned by the
+      lab when accessioning specimen(s). This is not necessarily the same as the specimen
+      identifier, depending on local lab procedures.'
+    element_property: true
+    title: Identifier assigned by the lab
+    type: string
+  bodySite:
+    backref: specimen
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: text representation. Anatomical location from which the specimen
+      was collected (if subject is a patient). This is the target site.  This element
+      is not used for environmental specimens.
+    element_property: true
+    enum_reference_types:
+    - BodyStructure
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Anatomical collection site
+    type: string
+  bodySite_coding: &id001
+    backref: specimen
+    binding_description: SNOMED CT Body site concepts
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/body-site
+    binding_version: null
+    description: '[system#code representation.] Anatomical location from which the
+      specimen was collected (if subject is a patient). This is the target site.  This
+      element is not used for environmental specimens.'
+    element_property: true
+    enum_reference_types:
+    - BodyStructure
+    term:
+      description: SNOMED CT Body site concepts
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/body-site
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/body-site
+        term_url: http://hl7.org/fhir/ValueSet/body-site
+    title: Anatomical collection site
+    type: string
+  bodySite_text: *id001
+  collection:
+    description: '[Text representation of SpecimenCollection] Details concerning the
+      specimen collection.'
+    element_property: true
+    title: Collection details
+    type: string
+  combined:
+    binding_description: Codes for the combined status of a specimen.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/specimen-combined
+    binding_version: 5.0.0
+    description: This element signifies if the specimen is part of a group or pooled.
+    element_property: true
+    enum_values:
+    - grouped
+    - pooled
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: grouped | pooled
+    type: string
+  condition:
+    binding_description: Codes describing the state of the specimen.
+    binding_strength: extensible
+    binding_uri: http://terminology.hl7.org/ValueSet/v2-0493
+    binding_version: null
+    description: text representation. A mode or state of being that describes the
+      nature of the specimen.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Codes describing the state of the specimen.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v2-0493
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://terminology.hl7.org/ValueSet/v2-0493
+        term_url: http://terminology.hl7.org/ValueSet/v2-0493
+    title: State of the specimen
+    type: array
+  condition_coding: &id002
+    binding_description: Codes describing the state of the specimen.
+    binding_strength: extensible
+    binding_uri: http://terminology.hl7.org/ValueSet/v2-0493
+    binding_version: null
+    description: '[system#code representation.] A mode or state of being that describes
+      the nature of the specimen.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Codes describing the state of the specimen.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v2-0493
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://terminology.hl7.org/ValueSet/v2-0493
+        term_url: http://terminology.hl7.org/ValueSet/v2-0493
+    title: State of the specimen
+    type: array
+  condition_text: *id002
+  container:
+    description: '[Text representation of SpecimenContainer] The container holding
+      the specimen.  The recursive nature of containers; i.e. blood in tube in tray
+      in rack is not addressed here.'
+    element_property: true
+    items:
+      type: string
+    title: Direct container of specimen (tube/slide, etc.)
+    type: array
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  feature:
+    description: '[Text representation of SpecimenFeature] A physical feature or landmark
+      on a specimen, highlighted for context by the collector of the specimen (e.g.
+      surgeon), that identifies the type of feature as well as its meaning (e.g. the
+      red ink indicating the resection margin of the right lobe of the excised prostate
+      tissue or wire loop at radiologically suspected tumor location).'
+    element_property: true
+    items:
+      type: string
+    title: The physical feature of a specimen
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Id for specimen.
+    element_property: true
+    items:
+      type: string
+    title: External Identifier
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Id for specimen.'
+    element_property: true
+    items:
+      type: string
+    title: External Identifier
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Id for specimen.'
+    element_property: true
+    items:
+      type: string
+    title: External Identifier
+    type: array
+  note:
+    description: '[Text representation of Annotation] To communicate any details or
+      issues about the specimen or during the specimen collection. (for example: broken
+      vial, sent with patient, frozen).'
+    element_property: true
+    items:
+      type: string
+    title: Comments
+    type: array
+  parent:
+    backref: parent_specimen
+    description: '[Text representation of Reference] Reference to the parent (source)
+      specimen which is used when the specimen was either derived from or a component
+      of another specimen.'
+    element_property: true
+    enum_reference_types:
+    - Specimen
+    items:
+      type: string
+    title: Specimen from which this specimen originated
+    type: array
+  processing_additive:
+    backref: additive_specimen_processing
+    description: '[Text representation of Reference] [Plucked from Specimen.processing]
+      Material used in the processing step'
+    element_property: true
+    enum_reference_types:
+    - Substance
+    items:
+      type: string
+    title: Material used in the processing step
+    type: array
+  processing_method:
+    binding_description: Type indicating the technique used to process the specimen.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/specimen-processing-method
+    binding_version: null
+    description: text representation. [Plucked from Specimen.processing] A coded value
+      specifying the method used to process the specimen.
+    element_property: true
+    term:
+      description: Type indicating the technique used to process the specimen.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/specimen-processing-method
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/specimen-processing-method
+        term_url: http://hl7.org/fhir/ValueSet/specimen-processing-method
+    title: Indicates the treatment step  applied to the specimen
+    type: string
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  receivedTime:
+    description: Time when specimen is received by the testing laboratory for processing
+      or testing.
+    element_property: true
+    format: date-time
+    title: The time when specimen is received by the testing laboratory
+    type: string
+  request:
+    backref: request_specimen
+    description: '[Text representation of Reference] Details concerning a service
+      request that required a specimen to be collected.'
+    element_property: true
+    enum_reference_types:
+    - ServiceRequest
+    items:
+      type: string
+    title: Why the specimen was collected
+    type: array
+  resourceType:
+    const: Specimen
+    default: Specimen
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  role:
+    binding_description: Codes describing specimen role.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/specimen-role
+    binding_version: null
+    description: text representation. The role or reason for the specimen in the testing
+      workflow.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Codes describing specimen role.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/specimen-role
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/specimen-role
+        term_url: http://hl7.org/fhir/ValueSet/specimen-role
+    title: The role the specimen serves
+    type: array
+  role_coding: &id003
+    binding_description: Codes describing specimen role.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/specimen-role
+    binding_version: null
+    description: '[system#code representation.] The role or reason for the specimen
+      in the testing workflow.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Codes describing specimen role.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/specimen-role
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/specimen-role
+        term_url: http://hl7.org/fhir/ValueSet/specimen-role
+    title: The role the specimen serves
+    type: array
+  role_text: *id003
+  status:
+    binding_description: Codes providing the status/availability of a specimen.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/specimen-status
+    binding_version: 5.0.0
+    description: The availability of the specimen.
+    element_property: true
+    enum_values:
+    - available
+    - unavailable
+    - unsatisfactory
+    - entered-in-error
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: available | unavailable | unsatisfactory | entered-in-error
+    type: string
+  subject:
+    backref: specimen
+    description: '[Text representation of Reference] Where the specimen came from.
+      This may be from patient(s), from a location (e.g., the source of an environmental
+      sample), or a sampling of a substance, a biologically-derived product, or a
+      device'
+    element_property: true
+    enum_reference_types:
+    - Patient
+    - Group
+    - Device
+    - BiologicallyDerivedProduct
+    - Substance
+    - Location
+    title: Where the specimen came from. This may be from patient(s), from a location
+      (e.g., the source of an environmental sample), or a sampling of a substance,
+      a biologically-derived product, or a device
+    type: string
+  type:
+    binding_description: The type of the specimen.
+    binding_strength: example
+    binding_uri: http://terminology.hl7.org/ValueSet/v2-0487
+    binding_version: null
+    description: text representation. The kind of material that forms the specimen.
+    element_property: true
+    term:
+      description: The type of the specimen.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v2-0487
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://terminology.hl7.org/ValueSet/v2-0487
+        term_url: http://terminology.hl7.org/ValueSet/v2-0487
+    title: Kind of material that forms the specimen
+    type: string
+  type_coding: &id004
+    binding_description: The type of the specimen.
+    binding_strength: example
+    binding_uri: http://terminology.hl7.org/ValueSet/v2-0487
+    binding_version: null
+    description: '[system#code representation.] The kind of material that forms the
+      specimen.'
+    element_property: true
+    term:
+      description: The type of the specimen.
+      termDef:
+        cde_id: http://terminology.hl7.org/ValueSet/v2-0487
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://terminology.hl7.org/ValueSet/v2-0487
+        term_url: http://terminology.hl7.org/ValueSet/v2-0487
+    title: Kind of material that forms the specimen
+    type: string
+  type_text: *id004
+title: Specimen
+type: object

--- a/tests/integration/data/schemas/substance.yaml
+++ b/tests/integration/data/schemas/substance.yaml
@@ -1,0 +1,212 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Clinical
+description: A homogeneous material with a definite composition. [See https://hl7.org/fhir/R5/Substance.html]
+id: substance
+links: []
+program: '*'
+project: '*'
+properties:
+  category:
+    binding_description: Category or classification of substance.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/substance-category
+    binding_version: null
+    description: text representation. A code that classifies the general type of substance.  This
+      is used  for searching, sorting and display purposes.
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Category or classification of substance.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/substance-category
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/substance-category
+        term_url: http://hl7.org/fhir/ValueSet/substance-category
+    title: What class/type of substance this is
+    type: array
+  category_coding: &id001
+    binding_description: Category or classification of substance.
+    binding_strength: extensible
+    binding_uri: http://hl7.org/fhir/ValueSet/substance-category
+    binding_version: null
+    description: '[system#code representation.] A code that classifies the general
+      type of substance.  This is used  for searching, sorting and display purposes.'
+    element_property: true
+    items:
+      type: string
+    term:
+      description: Category or classification of substance.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/substance-category
+        cde_version: null
+        source: fhir
+        strength: extensible
+        term: http://hl7.org/fhir/ValueSet/substance-category
+        term_url: http://hl7.org/fhir/ValueSet/substance-category
+    title: What class/type of substance this is
+    type: array
+  category_text: *id001
+  code:
+    backref: substance
+    binding_description: Substance codes.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/substance-code
+    binding_version: null
+    description: text representation. A code (or set of codes) that identify this
+      substance.
+    element_property: true
+    enum_reference_types:
+    - SubstanceDefinition
+    term:
+      description: Substance codes.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/substance-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/substance-code
+        term_url: http://hl7.org/fhir/ValueSet/substance-code
+    title: What substance this is
+    type: string
+  code_coding: &id002
+    backref: substance
+    binding_description: Substance codes.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/substance-code
+    binding_version: null
+    description: '[system#code representation.] A code (or set of codes) that identify
+      this substance.'
+    element_property: true
+    enum_reference_types:
+    - SubstanceDefinition
+    term:
+      description: Substance codes.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/substance-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/substance-code
+        term_url: http://hl7.org/fhir/ValueSet/substance-code
+    title: What substance this is
+    type: string
+  code_text: *id002
+  description:
+    description: A description of the substance - its appearance, handling requirements,
+      and other usage notes.
+    element_property: true
+    pattern: \s*(\S|\s)*
+    title: Textual description of the substance, comments
+    type: string
+  expiry:
+    description: When the substance is no longer valid to use. For some substances,
+      a single arbitrary date is used for expiry.
+    element_property: true
+    format: date-time
+    title: When no longer valid to use
+    type: string
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: Unique identifier for the substance. For an instance, an identifier
+      associated with the package/container (usually a label affixed directly).
+    element_property: true
+    items:
+      type: string
+    title: Unique identifier
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] Unique identifier for
+      the substance. For an instance, an identifier associated with the package/container
+      (usually a label affixed directly).'
+    element_property: true
+    items:
+      type: string
+    title: Unique identifier
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] Unique identifier
+      for the substance. For an instance, an identifier associated with the package/container
+      (usually a label affixed directly).'
+    element_property: true
+    items:
+      type: string
+    title: Unique identifier
+    type: array
+  ingredient:
+    description: '[Text representation of SubstanceIngredient] A substance can be
+      composed of other substances.'
+    element_property: true
+    items:
+      type: string
+    title: Composition information about the substance
+    type: array
+  instance:
+    description: A boolean to indicate if this an instance of a substance or a kind
+      of one (a definition).
+    element_property: true
+    element_required: true
+    title: Is this an instance of a substance or a kind of one
+    type: boolean
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  quantity:
+    description: '[Text representation of Quantity] text representation. The amount
+      of the substance.'
+    element_property: true
+    title: Amount of substance in the package
+    type: string
+  quantity_unit:
+    title: Unit representation. Amount of substance in the package
+    type: string
+  quantity_value:
+    title: Numerical value (with implicit precision) representation. Amount of substance
+      in the package
+    type: number
+  resourceType:
+    const: Substance
+    default: Substance
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  status:
+    binding_description: A code to indicate if the substance is actively used.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/substance-status
+    binding_version: 5.0.0
+    description: A code to indicate if the substance is actively used.
+    element_property: true
+    enum_values:
+    - active
+    - inactive
+    - entered-in-error
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: active | inactive | entered-in-error
+    type: string
+title: Substance
+type: object

--- a/tests/integration/data/schemas/task.yaml
+++ b/tests/integration/data/schemas/task.yaml
@@ -1,0 +1,598 @@
+$schema: http://json-schema.org/draft-04/schema#
+additionalProperties: true
+category: Analysis
+description: A task to be performed. [See https://hl7.org/fhir/R5/Task.html]
+id: task
+links:
+- backref: task
+  label: Task_encounter_Encounter_task
+  multiplicity: many_to_many
+  name: encounter
+  required: false
+  target_type: encounter
+- backref: task
+  label: Task_location_Location_task
+  multiplicity: many_to_many
+  name: location
+  required: false
+  target_type: location
+- backref: owner_task
+  label: Task_owner_Practitioner_owner_task
+  multiplicity: many_to_many
+  name: owner_Practitioner
+  required: false
+  target_type: practitioner
+- backref: owner_task
+  label: Task_owner_PractitionerRole_owner_task
+  multiplicity: many_to_many
+  name: owner_PractitionerRole
+  required: false
+  target_type: practitioner_role
+- backref: owner_task
+  label: Task_owner_Organization_owner_task
+  multiplicity: many_to_many
+  name: owner_Organization
+  required: false
+  target_type: organization
+- backref: owner_task
+  label: Task_owner_Patient_owner_task
+  multiplicity: many_to_many
+  name: owner_Patient
+  required: false
+  target_type: patient
+- backref: partOf_task
+  label: Task_partOf_Task_partOf_task
+  multiplicity: many_to_many
+  name: partOf
+  required: false
+  target_type: task
+- backref: task
+  label: Task_specimen_Specimen_task
+  multiplicity: many_to_many
+  name: specimen
+  required: false
+  target_type: specimen
+- backref: task
+  label: Task_document_reference_DocumentReference_task
+  multiplicity: many_to_many
+  name: document_reference
+  required: false
+  target_type: document_reference
+program: '*'
+project: '*'
+properties:
+  authoredOn:
+    description: The date and time this task was created.
+    element_property: true
+    format: date-time
+    title: Task Creation Date
+    type: string
+  basedOn:
+    backref: basedOn_task
+    description: '[Text representation of Reference] BasedOn refers to a higher-level
+      authorization that triggered the creation of the task.  It references a "request"
+      resource such as a ServiceRequest, MedicationRequest, CarePlan, etc. which is
+      distinct from the "request" resource the task is seeking to fulfill.  This latter
+      resource is referenced by focus.  For example, based on a CarePlan (= basedOn),
+      a task is created to fulfill a ServiceRequest ( = focus ) to collect a specimen
+      from a patient.'
+    element_property: true
+    enum_reference_types:
+    - Resource
+    items:
+      type: string
+    title: Request fulfilled by this task
+    type: array
+  businessStatus:
+    description: text representation. Contains business-specific nuances of the business
+      state.
+    element_property: true
+    title: E.g. "Specimen collected", "IV prepped"
+    type: string
+  businessStatus_coding: &id001
+    description: '[system#code representation.] Contains business-specific nuances
+      of the business state.'
+    element_property: true
+    title: E.g. "Specimen collected", "IV prepped"
+    type: string
+  businessStatus_text: *id001
+  code:
+    binding_description: Codes to identify what the task involves.  These will typically
+      be specific to a particular workflow.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/task-code
+    binding_version: null
+    description: text representation. A name or code (or both) briefly describing
+      what the task involves.
+    element_property: true
+    term:
+      description: Codes to identify what the task involves.  These will typically
+        be specific to a particular workflow.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/task-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/task-code
+        term_url: http://hl7.org/fhir/ValueSet/task-code
+    title: Task Type
+    type: string
+  code_coding: &id002
+    binding_description: Codes to identify what the task involves.  These will typically
+      be specific to a particular workflow.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/task-code
+    binding_version: null
+    description: '[system#code representation.] A name or code (or both) briefly describing
+      what the task involves.'
+    element_property: true
+    term:
+      description: Codes to identify what the task involves.  These will typically
+        be specific to a particular workflow.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/task-code
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/task-code
+        term_url: http://hl7.org/fhir/ValueSet/task-code
+    title: Task Type
+    type: string
+  code_text: *id002
+  description:
+    description: A free-text description of what is to be performed.
+    element_property: true
+    pattern: '[ \r\n\t\S]+'
+    title: Human-readable explanation of task
+    type: string
+  doNotPerform:
+    description: If true indicates that the Task is asking for the specified action
+      to *not* occur.
+    element_property: true
+    title: True if Task is prohibiting action
+    type: boolean
+  document_reference:
+    backref: task
+    description: '[Text representation of Reference] The output from this task.  Used
+      to generate link.'
+    enum_reference_types:
+    - DocumentReference
+    title: The output from this task.
+    type: string
+  encounter:
+    backref: task
+    description: '[Text representation of Reference] The healthcare event  (e.g. a
+      patient and healthcare provider interaction) during which this task was created.'
+    element_property: true
+    enum_reference_types:
+    - Encounter
+    title: Healthcare event during which this task originated
+    type: string
+  executionPeriod:
+    description: '[Text representation of Period] Identifies the time action was first
+      taken against the task (start) and/or the time final action was taken against
+      the task prior to marking it as completed (end).'
+    element_property: true
+    title: Start and end time of execution
+    type: string
+  extension:
+    description: '[Text representation of Extension] May be used to represent additional
+      information that is not part of the basic definition of the resource. To make
+      the use of extensions safe and managable, there is a strict set of governance
+      applied to the definition and use of extensions. Though any implementer can
+      define an extension, there is a set of requirements that SHALL be met as part
+      of the definition of the extension.'
+    element_property: true
+    items:
+      type: string
+    title: Additional content defined by implementations
+    type: array
+  focus:
+    backref: focus_task
+    description: '[Text representation of Reference] The request being fulfilled or
+      the resource being manipulated (changed, suspended, etc.) by this task.'
+    element_property: true
+    enum_reference_types:
+    - Resource
+    title: What task is acting on
+    type: string
+  for_fhir:
+    backref: for_task
+    description: '[Text representation of Reference] [Reserved word `for` renamed
+      to `for_fhir`] The entity who benefits from the performance of the service specified
+      in the task (e.g., the patient).'
+    element_property: true
+    enum_reference_types:
+    - Resource
+    title: Beneficiary of the Task
+    type: string
+  groupIdentifier:
+    description: '[Text representation of Identifier] A shared identifier common to
+      multiple independent Task and Request instances that were activated/authorized
+      more or less simultaneously by a single author.  The presence of the same identifier
+      on each request ties those requests together and may have business ramifications
+      in terms of reporting of results, billing, etc.  E.g. a requisition number shared
+      by a set of lab tests ordered together, or a prescription number shared by all
+      meds ordered at one time.'
+    element_property: true
+    title: Requisition or grouper id
+    type: string
+  id:
+    description: The logical id of the resource, as used in the URL for the resource.
+      Once assigned, this value never changes.
+    element_property: true
+    maxLength: 64
+    minLength: 1
+    pattern: ^[A-Za-z0-9\-.]+$
+    title: Logical id of this artifact
+    type: string
+  identifier:
+    description: The business identifier for this task.
+    element_property: true
+    items:
+      type: string
+    title: Task Instance Identifier
+    type: array
+  identifier_coding:
+    description: '[system#code representation of identifier] The business identifier
+      for this task.'
+    element_property: true
+    items:
+      type: string
+    title: Task Instance Identifier
+    type: array
+  identifier_text_coding:
+    description: '[system#code representation of identifier.text] The business identifier
+      for this task.'
+    element_property: true
+    items:
+      type: string
+    title: Task Instance Identifier
+    type: array
+  input_valueReference:
+    backref: task_input
+    description: '[Text representation of Reference] [Plucked from Task.input] The
+      value of the input parameter as a basic type.'
+    element_property: true
+    one_of_many: value
+    one_of_many_required: true
+    title: Content to use in performing the task
+    type: string
+  instantiatesCanonical:
+    description: The URL pointing to a *FHIR*-defined protocol, guideline, orderset
+      or other definition that is adhered to in whole or in part by this Task.
+    element_property: true
+    enum_reference_types:
+    - ActivityDefinition
+    pattern: \S*
+    title: Formal definition of task
+    type: string
+  instantiatesUri:
+    description: The URL pointing to an *externally* maintained  protocol, guideline,
+      orderset or other definition that is adhered to in whole or in part by this
+      Task.
+    element_property: true
+    pattern: \S*
+    title: Formal definition of task
+    type: string
+  insurance:
+    backref: insurance_task
+    description: '[Text representation of Reference] Insurance plans, coverage extensions,
+      pre-authorizations and/or pre-determinations that may be relevant to the Task.'
+    element_property: true
+    enum_reference_types:
+    - Coverage
+    - ClaimResponse
+    items:
+      type: string
+    title: Associated insurance coverage
+    type: array
+  intent:
+    binding_description: Distinguishes whether the task is a proposal, plan or full
+      order.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/task-intent
+    binding_version: 5.0.0
+    description: Indicates the "level" of actionability associated with the Task,
+      i.e. i+R[9]Cs this a proposed task, a planned task, an actionable task, etc.
+    element_property: true
+    element_required: true
+    enum_values:
+    - unknown
+    - proposal
+    - plan
+    - order
+    - original-order
+    - reflex-order
+    - filler-order
+    - instance-order
+    - option
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: unknown | proposal | plan | order | original-order | reflex-order | filler-order
+      | instance-order | option
+    type: string
+  lastModified:
+    description: The date and time of last modification to this task.
+    element_property: true
+    format: date-time
+    title: Task Last Modified Date
+    type: string
+  location:
+    backref: task
+    description: '[Text representation of Reference] Principal physical location where
+      this task is performed.'
+    element_property: true
+    enum_reference_types:
+    - Location
+    title: Where task occurs
+    type: string
+  note:
+    description: '[Text representation of Annotation] Free-text information captured
+      about the task as it progresses.'
+    element_property: true
+    items:
+      type: string
+    title: Comments made about the task
+    type: array
+  output_valueReference:
+    backref: task_output
+    description: '[Text representation of Reference] [Plucked from Task.output] The
+      value of the Output parameter as a basic type.'
+    element_property: true
+    one_of_many: value
+    one_of_many_required: true
+    title: Result of output
+    type: string
+  owner:
+    backref: owner_task
+    description: '[Text representation of Reference] Party responsible for managing
+      task execution.'
+    element_property: true
+    enum_reference_types:
+    - Practitioner
+    - PractitionerRole
+    - Organization
+    - CareTeam
+    - Patient
+    - RelatedPerson
+    title: Responsible individual
+    type: string
+  partOf:
+    backref: partOf_task
+    description: '[Text representation of Reference] Task that this particular task
+      is part of.'
+    element_property: true
+    enum_reference_types:
+    - Task
+    items:
+      type: string
+    title: Composite task
+    type: array
+  performer:
+    description: '[Text representation of TaskPerformer] The entity who performed
+      the requested task.'
+    element_property: true
+    items:
+      type: string
+    title: Who or what performed the task
+    type: array
+  priority:
+    binding_description: The priority of a task (may affect service level applied
+      to the task).
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/request-priority
+    binding_version: 5.0.0
+    description: Indicates how quickly the Task should be addressed with respect to
+      other requests.
+    element_property: true
+    enum_values:
+    - routine
+    - urgent
+    - asap
+    - stat
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: routine | urgent | asap | stat
+    type: string
+  project_id:
+    term:
+      $ref: _terms.yaml#/project_id
+    type: string
+  reason:
+    backref: reason_task
+    description: text representation. A description, code, or reference indicating
+      why this task needs to be performed.
+    element_property: true
+    items:
+      type: string
+    title: Why task is needed
+    type: array
+  reason_coding: &id003
+    backref: reason_task
+    description: '[system#code representation.] A description, code, or reference
+      indicating why this task needs to be performed.'
+    element_property: true
+    items:
+      type: string
+    title: Why task is needed
+    type: array
+  reason_text: *id003
+  relevantHistory:
+    backref: relevantHistory_task
+    description: '[Text representation of Reference] Links to Provenance records for
+      past versions of this Task that identify key state transitions or updates that
+      are likely to be relevant to a user looking at the current version of the task.'
+    element_property: true
+    enum_reference_types:
+    - Provenance
+    items:
+      type: string
+    title: Key events in history of the Task
+    type: array
+  requestedPerformer:
+    backref: requestedPerformer_task
+    binding_description: The type(s) of task performers allowed.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/performer-role
+    binding_version: null
+    description: text representation. The kind of participant or specific participant
+      that should perform the task.
+    element_property: true
+    enum_reference_types:
+    - Practitioner
+    - PractitionerRole
+    - Organization
+    - CareTeam
+    - HealthcareService
+    - Patient
+    - Device
+    - RelatedPerson
+    items:
+      type: string
+    term:
+      description: The type(s) of task performers allowed.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/performer-role
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/performer-role
+        term_url: http://hl7.org/fhir/ValueSet/performer-role
+    title: Who should perform Task
+    type: array
+  requestedPerformer_coding: &id004
+    backref: requestedPerformer_task
+    binding_description: The type(s) of task performers allowed.
+    binding_strength: preferred
+    binding_uri: http://hl7.org/fhir/ValueSet/performer-role
+    binding_version: null
+    description: '[system#code representation.] The kind of participant or specific
+      participant that should perform the task.'
+    element_property: true
+    enum_reference_types:
+    - Practitioner
+    - PractitionerRole
+    - Organization
+    - CareTeam
+    - HealthcareService
+    - Patient
+    - Device
+    - RelatedPerson
+    items:
+      type: string
+    term:
+      description: The type(s) of task performers allowed.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/performer-role
+        cde_version: null
+        source: fhir
+        strength: preferred
+        term: http://hl7.org/fhir/ValueSet/performer-role
+        term_url: http://hl7.org/fhir/ValueSet/performer-role
+    title: Who should perform Task
+    type: array
+  requestedPerformer_text: *id004
+  requestedPeriod:
+    description: '[Text representation of Period] Indicates the start and/or end of
+      the period of time when completion of the task is desired to take place.'
+    element_property: true
+    title: When the task should be performed
+    type: string
+  requester:
+    backref: requester_task
+    description: '[Text representation of Reference] The creator of the task.'
+    element_property: true
+    enum_reference_types:
+    - Device
+    - Organization
+    - Patient
+    - Practitioner
+    - PractitionerRole
+    - RelatedPerson
+    title: Who is asking for task to be done
+    type: string
+  resourceType:
+    const: Task
+    default: Task
+    description: One of the resource types defined as part of FHIR
+    title: Resource Type
+    type: string
+  restriction:
+    description: '[Text representation of TaskRestriction] If the Task.focus is a
+      request resource and the task is seeking fulfillment (i.e. is asking for the
+      request to be actioned), this element identifies any limitations on what parts
+      of the referenced request should be actioned.'
+    element_property: true
+    title: Constraints on fulfillment tasks
+    type: string
+  specimen:
+    backref: task
+    description: '[Text representation of Reference] The specimen input to this task.  Used
+      to generate link.'
+    enum_reference_types:
+    - Specimen
+    title: The specimen input to this task.
+    type: string
+  status:
+    binding_description: The current status of the task.
+    binding_strength: required
+    binding_uri: http://hl7.org/fhir/ValueSet/task-status
+    binding_version: 5.0.0
+    description: The current status of the task.
+    element_property: true
+    element_required: true
+    enum_values:
+    - draft
+    - requested
+    - received
+    - accepted
+    - +
+    pattern: ^[^\s]+(\s[^\s]+)*$
+    title: draft | requested | received | accepted | +
+    type: string
+  statusReason:
+    backref: task
+    binding_description: Codes to identify the reason for current status.  These will
+      typically be specific to a particular workflow.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/task-status-reason
+    binding_version: null
+    description: text representation. An explanation as to why this task is held,
+      failed, was refused, etc.
+    element_property: true
+    term:
+      description: Codes to identify the reason for current status.  These will typically
+        be specific to a particular workflow.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/task-status-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/task-status-reason
+        term_url: http://hl7.org/fhir/ValueSet/task-status-reason
+    title: Reason for current status
+    type: string
+  statusReason_coding: &id005
+    backref: task
+    binding_description: Codes to identify the reason for current status.  These will
+      typically be specific to a particular workflow.
+    binding_strength: example
+    binding_uri: http://hl7.org/fhir/ValueSet/task-status-reason
+    binding_version: null
+    description: '[system#code representation.] An explanation as to why this task
+      is held, failed, was refused, etc.'
+    element_property: true
+    term:
+      description: Codes to identify the reason for current status.  These will typically
+        be specific to a particular workflow.
+      termDef:
+        cde_id: http://hl7.org/fhir/ValueSet/task-status-reason
+        cde_version: null
+        source: fhir
+        strength: example
+        term: http://hl7.org/fhir/ValueSet/task-status-reason
+        term_url: http://hl7.org/fhir/ValueSet/task-status-reason
+    title: Reason for current status
+    type: string
+  statusReason_text: *id005
+title: Task
+type: object

--- a/tests/integration/data/test_pfb.py
+++ b/tests/integration/data/test_pfb.py
@@ -1,13 +1,27 @@
+import pathlib
+
 from iceberg_tools.data.pfb import SimplePFBWriter
 from iceberg_tools.data.simplifier import simplify_directory
+
+
+def setup_module(module):
+    """Setup the test module"""
+    msg = '\n'.join(
+        [
+            "# please run the following before running this test",
+            "iceberg schema generate simplified --config_path tests/integration/data/config.yaml --output_path tests/integration/data/schemas",
+            "iceberg schema compile simplified --output_path tests/integration/data/schemas"
+        ]
+    )
+    assert pathlib.Path('tests/integration/data/schemas/simplified-fhir.json').exists(), msg
 
 
 def test_studies(caplog, dependency_order):
     """Ensure we can create a pfb file from a synthetic study."""
     simplify_directory('tests/fixtures/simplify/study/', '**/*.*', 'tmp/study/extractions',
-                       'iceberg/schemas/simplified/simplified-fhir.json', 'PFB', 'config.yaml')
+                       'tests/integration/data/schemas/simplified-fhir.json', 'PFB', 'tests/integration/data/config.yaml')
 
-    pfb_writer = SimplePFBWriter(schema_path='iceberg/schemas/simplified/simplified-fhir.json',
+    pfb_writer = SimplePFBWriter(schema_path='tests/integration/data/schemas/simplified-fhir.json',
                                  output_path='tmp/CohesiveDataSet.avro',
                                  dependency_order=dependency_order)
 
@@ -22,9 +36,9 @@ def test_studies(caplog, dependency_order):
 def test_synthea(caplog, dependency_order):
     """Ensure we can create a pfb file from a synthetic study."""
     simplify_directory('tests/fixtures/simplify/synthea', '**/*.*', 'tmp/synthea/extractions',
-                       'iceberg/schemas/simplified/simplified-fhir.json', 'PFB', 'config.yaml')
+                       'tests/integration/data/schemas/simplified-fhir.json', 'PFB', 'tests/integration/data/config.yaml')
 
-    pfb_writer = SimplePFBWriter(schema_path='iceberg/schemas/simplified/simplified-fhir.json',
+    pfb_writer = SimplePFBWriter(schema_path='tests/integration/data/schemas/simplified-fhir.json',
                                  output_path='tmp/Synthea.avro',
                                  dependency_order=dependency_order)
 
@@ -39,9 +53,9 @@ def test_synthea(caplog, dependency_order):
 def test_kf(caplog, dependency_order):
     """Ensure we can create a pfb file from a Kids first study."""
     simplify_directory('tests/fixtures/simplify/kf', '**/*.*', 'tmp/kf/extractions',
-                       'iceberg/schemas/simplified/simplified-fhir.json', 'PFB', 'config.yaml')
+                       'tests/integration/data/schemas/simplified-fhir.json', 'PFB', 'tests/integration/data/config.yaml')
 
-    pfb_writer = SimplePFBWriter(schema_path='iceberg/schemas/simplified/simplified-fhir.json',
+    pfb_writer = SimplePFBWriter(schema_path='tests/integration/data/schemas/simplified-fhir.json',
                                  output_path='tmp/KidsFirst.avro',
                                  dependency_order=dependency_order)
 
@@ -57,9 +71,9 @@ def test_ncpi(caplog, dependency_order):
     """Ensure we can create a pfb file from a NCPI IG examples."""
 
     simplify_directory('tests/fixtures/simplify/ncpi/examples-5.0', '*.*', 'tmp/ncpi/extractions',
-                       'iceberg/schemas/simplified/simplified-fhir.json', 'PFB', 'config.yaml')
+                       'tests/integration/data/schemas/simplified-fhir.json', 'PFB', 'tests/integration/data/config.yaml')
 
-    pfb_writer = SimplePFBWriter(schema_path='iceberg/schemas/simplified/simplified-fhir.json',
+    pfb_writer = SimplePFBWriter(schema_path='tests/integration/data/schemas/simplified-fhir.json',
                                  output_path='tmp/NCPI.avro',
                                  dependency_order=dependency_order)
 
@@ -76,9 +90,9 @@ def test_genomics_reporting(caplog, dependency_order):
 
     simplify_directory('tests/fixtures/simplify/genomics-reporting/examples-5.0',
                        '*.*', 'tmp/genomics-reporting/extractions',
-                       'iceberg/schemas/simplified/simplified-fhir.json', 'PFB', 'config.yaml')
+                       'tests/integration/data/schemas/simplified-fhir.json', 'PFB', 'tests/integration/data/config.yaml')
 
-    pfb_writer = SimplePFBWriter(schema_path='iceberg/schemas/simplified/simplified-fhir.json',
+    pfb_writer = SimplePFBWriter(schema_path='tests/integration/data/schemas/simplified-fhir.json',
                                  output_path='tmp/GenomicsReporting.avro',
                                  dependency_order=dependency_order)
 
@@ -94,9 +108,9 @@ def test_dbgap(caplog, dependency_order):
     """Ensure we can create a pfb file from dbGAP examples."""
 
     simplify_directory('tests/fixtures/simplify/dbgap/examples-5.0', '*.*', 'tmp/dbgap/extractions',
-                       'iceberg/schemas/simplified/simplified-fhir.json', 'PFB', 'config.yaml')
+                       'tests/integration/data/schemas/simplified-fhir.json', 'PFB', 'tests/integration/data/config.yaml')
 
-    pfb_writer = SimplePFBWriter(schema_path='iceberg/schemas/simplified/simplified-fhir.json',
+    pfb_writer = SimplePFBWriter(schema_path='tests/integration/data/schemas/simplified-fhir.json',
                                  output_path='tmp/dbGap.avro',
                                  dependency_order=dependency_order)
 
@@ -112,9 +126,9 @@ def test_anvil(caplog, dependency_order):
     """Ensure we can create a pfb file from AnVIL examples."""
 
     simplify_directory('tests/fixtures/simplify/anvil/fhir-5.0/', '**/*.*', 'tmp/anvil/extractions',
-                       'iceberg/schemas/simplified/simplified-fhir.json', 'PFB', 'config.yaml')
+                       'tests/integration/data/schemas/simplified-fhir.json', 'PFB', 'tests/integration/data/config.yaml')
 
-    pfb_writer = SimplePFBWriter(schema_path='iceberg/schemas/simplified/simplified-fhir.json',
+    pfb_writer = SimplePFBWriter(schema_path='tests/integration/data/schemas/simplified-fhir.json',
                                  output_path='tmp/AnVIL.avro',
                                  dependency_order=dependency_order)
 


### PR DESCRIPTION
This PR fixes a schema change.  The current /config.yaml does not include organization, etc.   Therefore, we've created a separate config and associated schemas for the PFB testing